### PR TITLE
feat: add FeeTapper

### DIFF
--- a/snapshots/FeeTapperTest.json
+++ b/snapshots/FeeTapperTest.json
@@ -1,0 +1,14 @@
+{
+  "release_erc20Currency_single": "70126",
+  "release_erc20Currency_single_deletion": "45419",
+  "release_keg_erc20Currency_single": "69231",
+  "release_keg_erc20Currency_single_deletion": "47344",
+  "release_keg_nativeCurrency_single": "70973",
+  "release_keg_nativeCurrency_single_deletion": "45986",
+  "release_nativeCurrency_multiple": "88034",
+  "release_nativeCurrency_multiple_deletion": "59049",
+  "release_nativeCurrency_single": "71628",
+  "release_nativeCurrency_single_deletion": "40300",
+  "sync_existingTap": "29571",
+  "sync_newTap": "104048"
+}

--- a/src/feeAdapters/FeeTapper.sol
+++ b/src/feeAdapters/FeeTapper.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Currency, CurrencyLibrary} from "v4-core/types/Currency.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {Tap, Keg, IFeeTapper} from "../interfaces/IFeeTapper.sol";
+
+/// @title FeeTapper
+/// @notice Singleton contract which handles the streaming of incoming protocol fees to TokenJar
+contract FeeTapper is IFeeTapper, Ownable {
+  using CurrencyLibrary for Currency;
+
+  address public immutable tokenJar;
+
+  /// @notice Mapping of currencies to Taps
+  mapping(Currency => Tap) private $_taps;
+  /// @notice Linked list of kegs. Taps manage the head and tail of their respective kegs.
+  mapping(uint32 => Keg) private $_kegs;
+  /// @notice The id of the next keg to be created
+  uint32 public nextId;
+
+  /// @notice Basis points denominator
+  uint24 public constant BPS = 10_000;
+  /// @notice The release rate for accrued protocol fees in basis points per block.
+  ///         For example, at 10 basis points the full amount is released over 1_000 blocks.
+  /// @dev    This helps smooth out the release of fees which is useful for integrating with
+  /// TokenJar fee exchangers.
+  uint24 public perBlockReleaseRate = 10;
+
+  /// @notice The maximum supported balance to prevent overflowing a uint192
+  uint192 public constant MAX_BALANCE = type(uint192).max / BPS;
+
+  constructor(address _tokenJar, address _owner) Ownable(_owner) {
+    tokenJar = _tokenJar;
+  }
+
+  /// @notice Gets the tap for the given currency, if active
+  function taps(Currency currency) external view returns (Tap memory) {
+    return $_taps[currency];
+  }
+
+  /// @notice Gets the keg for the given id
+  function kegs(uint32 id) external view returns (Keg memory) {
+    return $_kegs[id];
+  }
+
+  /// @inheritdoc IFeeTapper
+  function setReleaseRate(uint24 _perBlockReleaseRate) external onlyOwner {
+    if (_perBlockReleaseRate == 0 || _perBlockReleaseRate > BPS) revert ReleaseRateOutOfBounds();
+    if (BPS % _perBlockReleaseRate != 0) revert InvalidReleaseRate();
+    perBlockReleaseRate = _perBlockReleaseRate;
+    emit ReleaseRateSet(_perBlockReleaseRate);
+  }
+
+  /// @inheritdoc IFeeTapper
+  function sync(Currency currency) external {
+    Tap storage $tap = $_taps[currency];
+    // Silently truncates any received balances over uint192.max
+    uint192 balance = uint192(currency.balanceOfSelf());
+    // Revert if the amount added to the tap would eventually overflow a uint192
+    if (balance > MAX_BALANCE) revert AmountTooLarge();
+    uint192 oldBalance = $tap.balance;
+    // noop if there hasn't been a change in balance
+    if (balance == oldBalance) return;
+
+    unchecked {
+      nextId++;
+    }
+    uint32 next = nextId;
+
+    uint48 endBlock = uint48(block.number + BPS / perBlockReleaseRate);
+    uint192 amount = balance - oldBalance;
+
+    $_kegs[next] = Keg({
+      currency: currency,
+      perBlockReleaseAmount: amount * perBlockReleaseRate,
+      lastReleaseBlock: uint48(block.number),
+      endBlock: endBlock,
+      next: 0
+    });
+    if ($tap.head == 0) {
+      $tap.head = next;
+      $tap.tail = next;
+    } else {
+      $_kegs[$tap.tail].next = next;
+      $tap.tail = next;
+    }
+    $tap.balance = balance;
+
+    emit Deposited(next, Currency.unwrap(currency), amount, endBlock);
+    emit Synced(Currency.unwrap(currency), balance);
+  }
+
+  /// @inheritdoc IFeeTapper
+  function release(uint32 id) external returns (uint192) {
+    Keg memory keg = $_kegs[id];
+    return _process(keg.currency, _release(keg, id));
+  }
+
+  /// @inheritdoc IFeeTapper
+  function releaseAll(Currency currency) external returns (uint192) {
+    return _process(currency, _releaseAll(currency));
+  }
+
+  /// @notice Releases a single keg for a given currency
+  /// @param id The id of the keg to release
+  function _release(Keg memory keg, uint32 id) internal returns (uint192 releasedAmount) {
+    uint48 minBlock = uint48(_min(block.number, keg.endBlock));
+    releasedAmount = uint192(keg.perBlockReleaseAmount * (minBlock - keg.lastReleaseBlock));
+    // Set the lastReleaseBlock such that after the endBlock, releasedAmount will be zero
+    $_kegs[id].lastReleaseBlock = minBlock;
+    return releasedAmount;
+  }
+
+  /// @notice Releases all kegs for a given currency
+  function _releaseAll(Currency currency) internal returns (uint192 releasedAmount) {
+    Tap storage $tap = $_taps[currency];
+    if ($tap.balance == 0) return 0;
+
+    uint32 prev = 0;
+    uint32 curr = $tap.head;
+    uint256 blockNumber = block.number;
+    // Itereate through all kegs. This can be very costly if there are lot of kegs.
+    while (curr != 0) {
+      Keg memory keg = $_kegs[curr];
+      uint32 next = keg.next;
+
+      releasedAmount += _release(keg, curr);
+
+      if (keg.endBlock <= blockNumber) {
+        // unlink the current keg
+        if (prev == 0) {
+          // deleting head
+          $tap.head = next;
+        } else {
+          $_kegs[prev].next = next;
+        }
+        // if we removed the tail (next == 0 after unlink), update tail
+        if (next == 0) $tap.tail = prev;
+        delete $_kegs[curr];
+      } else {
+        // only advance prev when the current keg remains linked
+        prev = curr;
+      }
+
+      curr = next;
+    }
+    return releasedAmount;
+  }
+
+  /// @notice Transfers the released amount to the token jar
+  function _process(Currency _currency, uint192 _releasedAmount) internal returns (uint192) {
+    // Because we deferred dividing by BPS when storing the perBlockReleaseAmount, we need to divide
+    // now
+    uint192 toRelease = _releasedAmount / BPS;
+    // Update the tap balance
+    $_taps[_currency].balance -= toRelease;
+
+    if (toRelease > 0) {
+      _currency.transfer(tokenJar, toRelease);
+      emit Released(Currency.unwrap(_currency), toRelease);
+    }
+    return toRelease;
+  }
+
+  function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+    return a < b ? a : b;
+  }
+
+  /// @notice Receives ETH
+  receive() external payable {}
+}

--- a/src/interfaces/IFeeTapper.sol
+++ b/src/interfaces/IFeeTapper.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Currency, CurrencyLibrary} from "v4-core/types/Currency.sol";
+
+/// @notice Struct representing an active tap for a given currency
+struct Tap {
+  uint192 balance; /// @notice The last synced balance of the tap
+  uint32 head; /// @notice The head of the linked list of kegs
+  uint32 tail; /// @notice The tail of the linked list of kegs
+}
+
+/// @notice Struct representing a unique currency deposit
+struct Keg {
+  Currency currency; /// @notice The currency associated with the keg
+  uint48 endBlock; /// @notice The block at which the deposit will be fully released
+  uint48 lastReleaseBlock; /// @notice The block at which the last release was made
+  uint192 perBlockReleaseAmount; /// @notice The absolute amount of the currency released per block
+  uint32 next; /// @notice The next keg in the linked list
+}
+
+/// @title IFeeTapper
+interface IFeeTapper {
+  /// @notice Error thrown when the balance is too large
+  error AmountTooLarge();
+
+  /// @notice Error thrown when the release rate is zero or larger than BPS
+  error ReleaseRateOutOfBounds();
+
+  /// @notice Error thrown when the rate does not evenly divide BPS
+  error InvalidReleaseRate();
+
+  /// @notice Emitted when a new deposit is synced
+  /// @param id The unique id of the deposit
+  /// @param currency The currency being deposited
+  /// @param amount The amount of protocol fees deposited
+  /// @param endBlock The block at which the deposit will be fully released
+  event Deposited(uint64 indexed id, address indexed currency, uint192 amount, uint64 endBlock);
+
+  /// @notice Emitted when a Tap is synced
+  /// @param currency The currency being synced
+  /// @param balance The new balance of the tap
+  event Synced(address indexed currency, uint192 balance);
+
+  /// @notice Emitted when protocol fees are released
+  /// @param currency The currency being released
+  /// @param amount The amount of protocol fees released
+  event Released(address indexed currency, uint192 amount);
+
+  /// @notice Emitted when the release rate is set
+  /// @param rate The new release rate
+  event ReleaseRateSet(uint24 rate);
+
+  /// @notice Sets the release rate for accrued protocol fees in basis points per block. Only
+  /// callable by the owner. @dev Rate must be non zero and <= BPS and evenly divisible by BPS.
+  /// @param _perBlockReleaseRate The new release rate in basis points per block
+  function setReleaseRate(uint24 _perBlockReleaseRate) external;
+
+  /// @notice Syncs the fee tapper with received protocol fees. Callable by anyone
+  /// @dev Creates a new Tap for the currency if it does not exist already
+  /// @param currency The currency to sync
+  function sync(Currency currency) external;
+
+  /// @notice Releases a single keg. Each keg is a unique deposit of fees
+  /// @dev Unlike releaseAll this function does not remove empty kegs from the list
+  /// @param id The id of the keg to release
+  function release(uint32 id) external returns (uint192);
+
+  /// @notice Releases all accumulated protocol fees for a given currency to the token jar
+  /// @dev This function will loop through all active kegs for the given currency
+  /// @param currency The currency to release
+  function releaseAll(Currency currency) external returns (uint192);
+
+  /// Getters
+
+  /// @notice Gets the tap for the given currency
+  /// @param currency The currency to get the tap for
+  function taps(Currency currency) external view returns (Tap memory);
+
+  /// @notice Gets the keg for the given id
+  /// @dev You MUST find the corresponding tap holding the keg before using the returned values
+  /// @param id The id of the keg to get
+  function kegs(uint32 id) external view returns (Keg memory);
+}

--- a/test/FeeTapper.t.sol
+++ b/test/FeeTapper.t.sol
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {FeeTapper} from "../src/feeAdapters/FeeTapper.sol";
+import {IFeeTapper} from "../src/interfaces/IFeeTapper.sol";
+import {Currency, CurrencyLibrary} from "v4-core/types/Currency.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {ERC20Mock} from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+contract FeeTapperTest is Test {
+  using CurrencyLibrary for Currency;
+
+  FeeTapper public feeTapper;
+  address public tokenJar = makeAddr("tokenJar");
+  address public owner = makeAddr("owner");
+
+  ERC20Mock public erc20Currency;
+
+  uint24 public constant BPS = 10_000;
+
+  function setUp() public {
+    feeTapper = new FeeTapper(tokenJar, owner);
+    vm.deal(address(this), type(uint256).max);
+    erc20Currency = new ERC20Mock();
+  }
+
+  function _deal(address to, uint256 amount, bool useNativeCurrency) internal {
+    if (useNativeCurrency) _dealETH(to, amount);
+    else _dealERC20(to, amount);
+  }
+
+  function _dealETH(address to, uint256 amount) internal {
+    (bool success,) = address(to).call{value: amount}("");
+    require(success, "ETH transfer failed");
+  }
+
+  function _dealERC20(address to, uint256 amount) internal {
+    erc20Currency.mint(to, amount);
+  }
+
+  function test_setPerBlockReleaseRate_reverts_notOwner(uint24 _perBlockReleaseRate) public {
+    address notOwner = makeAddr("notOwner");
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
+    vm.prank(notOwner);
+    feeTapper.setReleaseRate(_perBlockReleaseRate);
+  }
+
+  function test_setReleaseRate_WhenEqZero() public {
+    // it reverts with {ReleaseRateOutOfBounds()}
+
+    vm.prank(owner);
+    vm.expectRevert(IFeeTapper.ReleaseRateOutOfBounds.selector);
+    feeTapper.setReleaseRate(0);
+  }
+
+  function test_setReleaseRate_WhenGtBPS(uint24 _perBlockReleaseRate) public {
+    // it reverts with {ReleaseRateOutOfBounds()}
+
+    _perBlockReleaseRate = uint24(bound(_perBlockReleaseRate, BPS + 1, type(uint24).max));
+
+    vm.prank(owner);
+    vm.expectRevert(IFeeTapper.ReleaseRateOutOfBounds.selector);
+    feeTapper.setReleaseRate(_perBlockReleaseRate);
+  }
+
+  function test_setReleaseRate_WhenNotDivisibleByBPS(uint24 _perBlockReleaseRate) public {
+    // it reverts with {InvalidReleaseRate()}
+
+    _perBlockReleaseRate = uint24(bound(_perBlockReleaseRate, 1, BPS - 1));
+    vm.assume(BPS % _perBlockReleaseRate != 0);
+
+    vm.prank(owner);
+    vm.expectRevert(IFeeTapper.InvalidReleaseRate.selector);
+    feeTapper.setReleaseRate(_perBlockReleaseRate);
+  }
+
+  function test_setReleaseRate_WhenLTEBPSAndDivisibleByBPS(uint24 _perBlockReleaseRate) public {
+    // it succeeds
+
+    _perBlockReleaseRate = uint24(bound(_perBlockReleaseRate, 1, BPS));
+    vm.assume(BPS % _perBlockReleaseRate == 0);
+
+    vm.prank(owner);
+    vm.expectEmit(true, true, true, true);
+    emit IFeeTapper.ReleaseRateSet(_perBlockReleaseRate);
+    feeTapper.setReleaseRate(_perBlockReleaseRate);
+    assertEq(feeTapper.perBlockReleaseRate(), _perBlockReleaseRate);
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_sync_gas() public {
+    Currency currency = Currency.wrap(address(erc20Currency));
+    deal(address(erc20Currency), address(feeTapper), 1e18);
+    feeTapper.sync(currency);
+    vm.snapshotGasLastCall("sync_newTap");
+
+    deal(address(erc20Currency), address(feeTapper), 1e18);
+    feeTapper.sync(currency);
+    vm.snapshotGasLastCall("sync_existingTap");
+  }
+
+  function test_sync_WhenAmountIsTooLarge() public {
+    // it reverts with {AmountTooLarge()}
+
+    Currency currency = Currency.wrap(address(erc20Currency));
+    deal(address(erc20Currency), address(feeTapper), feeTapper.MAX_BALANCE() + 1);
+    vm.expectRevert(IFeeTapper.AmountTooLarge.selector);
+    feeTapper.sync(currency);
+  }
+
+  function test_sync_WhenCurrencyIsNotAddressZero(uint192 _feeAmount) public {
+    // it emits a {Synced()} event
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency = Currency.wrap(address(erc20Currency));
+
+    deal(address(erc20Currency), address(feeTapper), _feeAmount);
+
+    vm.expectEmit(true, true, true, true);
+    emit IFeeTapper.Synced(Currency.unwrap(currency), _feeAmount);
+    feeTapper.sync(currency);
+    assertEq(feeTapper.taps(currency).balance, _feeAmount);
+  }
+
+  function test_sync_WhenCurrencyIsAddressZeroAndTapIsNotEmpty(
+    uint192 _feeAmount,
+    uint192 _additionalFeeAmount,
+    uint64 _elapsed,
+    bool _useNativeCurrency
+  ) public {
+    // it adds fee amount to the tap balance
+    // it creates a new keg
+    // it emits a {Deposited()} event
+    // it emits a {Synced()} event
+
+    // Low bounds to avoid overflows later on
+    _feeAmount = uint192(bound(_feeAmount, 1, type(uint64).max));
+    _additionalFeeAmount = uint192(bound(_additionalFeeAmount, 1, type(uint64).max));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+    assertEq(feeTapper.taps(currency).balance, _feeAmount);
+
+    _deal(address(feeTapper), _additionalFeeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+    assertEq(feeTapper.taps(currency).balance, _feeAmount + _additionalFeeAmount);
+
+    _elapsed = uint64(bound(_elapsed, 1, BPS / feeTapper.perBlockReleaseRate()));
+
+    vm.roll(block.number + _elapsed);
+    uint256 released = feeTapper.releaseAll(currency);
+    assertEq(
+      released,
+      (_feeAmount + _additionalFeeAmount) * feeTapper.perBlockReleaseRate() * _elapsed / BPS
+    );
+  }
+
+  function test_release_WhenTapAmountIsZero(Currency currency) public {
+    // it returns 0
+
+    uint256 amount = feeTapper.releaseAll(currency);
+    assertEq(amount, 0);
+  }
+
+  function test_release_WhenElapsedIsZero(uint192 _feeAmount) public {
+    // it returns 0
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency = Currency.wrap(address(0));
+    _deal(address(feeTapper), _feeAmount, true);
+    feeTapper.sync(currency);
+
+    assertEq(feeTapper.taps(currency).balance, _feeAmount);
+
+    uint256 amount = feeTapper.releaseAll(currency);
+    assertEq(amount, 0);
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_release_nativeCurrency_single_gas() public {
+    Currency currency = Currency.wrap(address(0));
+    _deal(address(feeTapper), 1e18, true);
+    feeTapper.sync(currency);
+
+    vm.roll(block.number + 1);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_nativeCurrency_single");
+
+    vm.roll(block.number + BPS);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_nativeCurrency_single_deletion");
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_release_keg_nativeCurrency_gas() public {
+    Currency currency = Currency.wrap(address(0));
+    _deal(address(feeTapper), 1e18, true);
+    feeTapper.sync(currency);
+
+    vm.roll(block.number + 1);
+    feeTapper.release(1);
+    vm.snapshotGasLastCall("release_keg_nativeCurrency_single");
+
+    vm.roll(block.number + BPS);
+    feeTapper.release(1);
+    vm.snapshotGasLastCall("release_keg_nativeCurrency_single_deletion");
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_release_erc20Currency_single_gas() public {
+    Currency currency = Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), 1e18, false);
+    feeTapper.sync(currency);
+
+    vm.roll(block.number + 1);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_erc20Currency_single");
+
+    vm.roll(block.number + BPS);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_erc20Currency_single_deletion");
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_release_keg_erc20Currency_gas() public {
+    Currency currency = Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), 1e18, false);
+    feeTapper.sync(currency);
+
+    vm.roll(block.number + 1);
+    feeTapper.release(1);
+    vm.snapshotGasLastCall("release_keg_erc20Currency_single");
+
+    vm.roll(block.number + BPS);
+    feeTapper.release(1);
+    vm.snapshotGasLastCall("release_keg_erc20Currency_single_deletion");
+  }
+
+  /// forge-config: default.isolate = true
+  /// forge-config: ci.isolate = true
+  function test_release_nativeCurrency_multiple_gas() public {
+    Currency currency = Currency.wrap(address(0));
+    for (uint64 i = 0; i < 3; i++) {
+      _deal(address(feeTapper), 1e18, true);
+      feeTapper.sync(currency);
+    }
+
+    vm.roll(block.number + 1);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_nativeCurrency_multiple");
+
+    vm.roll(block.number + BPS);
+    feeTapper.releaseAll(currency);
+    vm.snapshotGasLastCall("release_nativeCurrency_multiple_deletion");
+  }
+
+  function test_release_WhenToReleaseIsGreaterThanTapAmount(uint192 _feeAmount, uint64 _elapsed)
+    public
+  {
+    // it returns the rest of the tap amount
+
+    _elapsed = uint64(bound(_elapsed, BPS / feeTapper.perBlockReleaseRate(), type(uint64).max));
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency = Currency.wrap(address(0));
+    _deal(address(feeTapper), _feeAmount, true);
+    feeTapper.sync(currency);
+
+    // ensure that there is more to release than the tap amount
+    vm.roll(block.number + _elapsed);
+
+    uint256 amount = feeTapper.releaseAll(currency);
+    assertEq(amount, _feeAmount);
+    assertEq(feeTapper.taps(currency).balance, 0);
+  }
+
+  function test_release_WhenToReleaseIsLTEThanTapAmount(
+    uint192 _feeAmount,
+    uint64 _elapsed,
+    bool _useNativeCurrency
+  ) public {
+    // it updates the tap amount
+    // it emits a {Released()} event
+
+    _elapsed = uint64(bound(_elapsed, 1, BPS / feeTapper.perBlockReleaseRate()));
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    assertEq(feeTapper.taps(currency).balance, _feeAmount);
+
+    vm.roll(block.number + _elapsed);
+    vm.expectEmit(true, true, true, true);
+    uint192 expectedReleased = (_feeAmount * feeTapper.perBlockReleaseRate() * _elapsed) / BPS;
+    emit IFeeTapper.Released(Currency.unwrap(currency), expectedReleased);
+    vm.assume(expectedReleased > 0);
+    uint192 released = feeTapper.releaseAll(currency);
+    assertEq(released, expectedReleased);
+    assertEq(feeTapper.taps(currency).balance, _feeAmount - released);
+  }
+
+  function test_release_IsLinear(uint192 _feeAmount, bool _useNativeCurrency) public {
+    // it releases the amount of protocol fees based on the release rate
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint256 snapshotId = vm.snapshot();
+
+    // Maximize number of releases by calling one per block
+    uint192 totalReleased = 0;
+    uint256 maxDust = 0;
+    for (uint64 i = 0; i < BPS / feeTapper.perBlockReleaseRate(); i++) {
+      vm.roll(block.number + 1);
+      totalReleased += feeTapper.releaseAll(currency);
+      maxDust++;
+    }
+
+    vm.revertTo(snapshotId);
+
+    // Now test releasing all in one go after BPS / perBlockReleaseRate() blocks
+    vm.roll(block.number + BPS / feeTapper.perBlockReleaseRate());
+    uint256 endTotalReleased = feeTapper.releaseAll(currency);
+    assertApproxEqAbs(endTotalReleased, totalReleased, maxDust, "total released should be the same");
+  }
+
+  function test_release_WhenEmptyKegsAreReleased(
+    uint192 _feeAmount,
+    uint192 _additionalFeeAmount,
+    bool _useNativeCurrency
+  ) public {
+    // it does not delete the keg when fully released
+    // it does not update the head/tail of the tap
+    // after adding a new keg, the old keg is deleted
+    // after releasing the new keg, it becomes the head/tail of the tap
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE()));
+    _additionalFeeAmount = uint192(bound(_additionalFeeAmount, 1, feeTapper.MAX_BALANCE()));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint48 endBlock = uint48(block.number + BPS / feeTapper.perBlockReleaseRate());
+
+    vm.roll(block.number + BPS / feeTapper.perBlockReleaseRate());
+    uint192 released = feeTapper.release(1);
+    assertEq(released, _feeAmount);
+    assertEq(feeTapper.taps(currency).balance, 0);
+
+    // assert that the keg is not deleted
+    assertEq(feeTapper.taps(currency).head, 1);
+    assertEq(feeTapper.taps(currency).tail, 1);
+    assertEq(feeTapper.kegs(1).perBlockReleaseAmount, _feeAmount * feeTapper.perBlockReleaseRate());
+    assertEq(feeTapper.kegs(1).endBlock, endBlock);
+
+    // make another deposit
+    _deal(address(feeTapper), _additionalFeeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    vm.roll(block.number + 1);
+    released = feeTapper.releaseAll(currency);
+
+    // assert that the old keg is deleted and the new keg is the head/tail
+    assertEq(feeTapper.taps(currency).head, 2);
+    assertEq(feeTapper.taps(currency).tail, 2);
+    assertEq(feeTapper.kegs(1).perBlockReleaseAmount, 0);
+    assertEq(feeTapper.kegs(1).endBlock, 0);
+
+    // assert that after the full release, the head/tail are reset
+    vm.roll(block.number + BPS / feeTapper.perBlockReleaseRate());
+    released = feeTapper.releaseAll(currency);
+    assertEq(feeTapper.taps(currency).head, 0);
+    assertEq(feeTapper.taps(currency).tail, 0);
+  }
+
+  function test_release_WhenMiddleKegIsReleased(uint192 _feeAmount, bool _useNativeCurrency)
+    public
+  {
+    // it deletes the keg when fully released
+    // it keeps the current head/tail of the tap
+    // it links the head to the next keg
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE() / 3));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint24 originalReleaseRate = feeTapper.perBlockReleaseRate();
+    // Modify the release rate to have the second keg run out before the first and third. It will
+    // run out in a block
+    vm.prank(owner);
+    feeTapper.setReleaseRate(BPS);
+
+    // add a second keg
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // Change the release rate back to the original
+    vm.prank(owner);
+    feeTapper.setReleaseRate(originalReleaseRate);
+
+    // add a third keg
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // release the middle keg
+    vm.roll(block.number + 1);
+    uint192 released = feeTapper.releaseAll(currency);
+    assertEq(released, _feeAmount + (_feeAmount * originalReleaseRate * 2) / BPS);
+    // Same head and tail
+    assertEq(feeTapper.taps(currency).head, 1);
+    assertEq(feeTapper.taps(currency).tail, 3);
+    assertEq(feeTapper.kegs(1).next, 3);
+    assertEq(feeTapper.kegs(3).next, 0);
+  }
+
+  function test_release_WhenMultipleKegsAreReleased(uint192 _feeAmount, bool _useNativeCurrency)
+    public
+  {
+    // it moves the head over multiple
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE() / 3));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // add a second keg
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint48 endBlock = uint48(block.number + BPS / feeTapper.perBlockReleaseRate());
+
+    vm.roll(block.number + 1);
+    // add a third keg
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // roll to the end of the first two releases
+    vm.roll(endBlock);
+    feeTapper.releaseAll(currency);
+    // head should have been moved from 1 -> 2 -> 3
+    assertEq(feeTapper.taps(currency).head, 3);
+    assertEq(feeTapper.taps(currency).tail, 3);
+    assertEq(feeTapper.kegs(1).perBlockReleaseAmount, 0); // deleted
+    assertEq(feeTapper.kegs(1).next, 0); // deleted
+    assertEq(feeTapper.kegs(2).perBlockReleaseAmount, 0); // deleted
+    assertEq(feeTapper.kegs(2).next, 0); // deleted
+    assertEq(feeTapper.kegs(3).next, 0); // last one
+  }
+
+  function test_release_WhenTailKegEndsBeforeHead_ReLinksCorrectly(
+    uint192 _feeAmount,
+    bool _useNativeCurrency
+  ) public {
+    // it deletes the finished tail keg and keeps the list linked for new deposits
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE() / 3));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+
+    // first keg with the default, slower release rate
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint24 originalReleaseRate = feeTapper.perBlockReleaseRate();
+
+    // speed up release so the next keg finishes first
+    vm.prank(owner);
+    feeTapper.setReleaseRate(BPS);
+
+    // second keg (will end in 1 block)
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // advance so the tail keg ends while the head is still active
+    vm.roll(block.number + 1);
+    uint192 released = feeTapper.releaseAll(currency);
+    assertGt(released, 0);
+
+    // tail was removed; head remains
+    assertEq(feeTapper.taps(currency).head, 1);
+    assertEq(feeTapper.taps(currency).tail, 1);
+    assertEq(feeTapper.kegs(1).next, 0);
+
+    // restore original rate and add a new keg; it should link after the head
+    vm.prank(owner);
+    feeTapper.setReleaseRate(originalReleaseRate);
+
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    assertEq(feeTapper.taps(currency).head, 1);
+    assertEq(feeTapper.taps(currency).tail, 3);
+    assertEq(feeTapper.kegs(1).next, 3);
+    assertEq(feeTapper.kegs(3).next, 0);
+  }
+
+  function test_release_WhenConsecutiveFinishedKegsBehindActiveHead_ReLinksCorrectly(
+    uint192 _feeAmount,
+    bool _useNativeCurrency
+  ) public {
+    // it deletes consecutive finished middle kegs and keeps the tail reachable
+
+    _feeAmount = uint192(bound(_feeAmount, 1, feeTapper.MAX_BALANCE() / 4));
+
+    Currency currency =
+      _useNativeCurrency ? Currency.wrap(address(0)) : Currency.wrap(address(erc20Currency));
+
+    // Keg A (head) with slow release
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    uint24 originalReleaseRate = feeTapper.perBlockReleaseRate();
+
+    // Speed up to make middle kegs finish quickly
+    vm.prank(owner);
+    feeTapper.setReleaseRate(BPS);
+
+    // Keg B
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // Keg C
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // Restore slower rate for tail keg D
+    vm.prank(owner);
+    feeTapper.setReleaseRate(originalReleaseRate);
+
+    // Keg D (tail, long-lived)
+    _deal(address(feeTapper), _feeAmount, _useNativeCurrency);
+    feeTapper.sync(currency);
+
+    // Roll so B and C have fully ended while A and D are still active
+    vm.roll(block.number + 1);
+
+    uint192 released = feeTapper.releaseAll(currency);
+    assertGt(released, 0);
+
+    // A should link directly to D; tail is D; B and C are deleted
+    assertEq(feeTapper.taps(currency).head, 1);
+    assertEq(feeTapper.taps(currency).tail, 4);
+    assertEq(feeTapper.kegs(1).next, 4);
+    assertEq(feeTapper.kegs(4).next, 0);
+    assertEq(feeTapper.kegs(2).perBlockReleaseAmount, 0);
+    assertEq(feeTapper.kegs(3).perBlockReleaseAmount, 0);
+  }
+}


### PR DESCRIPTION
The recipient is intended to be `FeeTapper`, a singleton contract which holds a multitude of active deposits. Each currency has a unique `Tap`, which tracks its balance over time. Each call to `sync` creates a new deposit, also called `Keg`. Each `Keg` holds a per block release amount and an end block. Kegs can be released in batch (all at once per currency, or one by one). Kegs are stored in a flat linked list in storage and Taps hold pointers to the head/tail within the list.

`FeeTapper` streams fees over time, ensuring that large fee payments are incrementally sent to the fee recipient. For more details on the token jar implementation, check out the https://github.com/Uniswap/protocol-fees/blob/main/src/releasers/ExchangeReleaser.sol  

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Adds the FeeTapper contract, a singleton that handles streaming protocol fees to TokenJar using a configurable per-block release rate to smooth fee distribution.
## Changes
- Add `src/feeAdapters/FeeTapper.sol` - Singleton contract managing fee streaming with linked-list "kegs" for each currency "tap"
- Add `src/interfaces/IFeeTapper.sol` - Interface defining Tap/Keg structs and contract methods
- Add `test/FeeTapper.t.sol` - Comprehensive test suite (573 lines) covering sync, release, and edge cases
- Add `snapshots/FeeTapperTest.json` - Gas benchmarks for operations
## Key Features
- **Linear fee release**: Fees are released over time based on `perBlockReleaseRate` (default 10 bps/block = 1000 blocks for full release)
- **Multi-currency support**: Handles both native ETH and ERC20 tokens
- **Keg management**: Each deposit creates a "keg" with its own release schedule; empty kegs are automatically cleaned up via linked list operations
- **Owner controls**: Release rate configurable by owner (must evenly divide 10000 bps)
- **Gas efficient**: Single keg release ~70k gas, multiple keg release with cleanup ~88k gas
<!-- claude-pr-description-end -->