### PR TITLE
V4 fee adapter

### DIFF
--- a/script/05_V4FeeSwitchProposal.s.sol
+++ b/script/05_V4FeeSwitchProposal.s.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {console2} from "forge-std/console2.sol";
+import {Script} from "forge-std/Script.sol";
+import {StdAssertions} from "forge-std/StdAssertions.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {IProtocolFees} from "v4-core/interfaces/IProtocolFees.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {V4FeeAdapter} from "../src/feeAdapters/V4FeeAdapter.sol";
+
+struct ProposalAction {
+  address target;
+  uint256 value;
+  string signature;
+  bytes data;
+}
+
+/// @title V4FeeSwitchProposal
+/// @notice Governance proposal to activate protocol fees on Uniswap V4
+/// @dev Requires V4FeeAdapter to be deployed first via V4MainnetDeployer.
+///      This proposal:
+///      1. Sets the V4FeeAdapter as the protocol fee controller on the PoolManager
+///      2. Configures default and tier-based protocol fees
+///      3. Applies fees to a set of initial pools
+contract V4FeeSwitchProposal is Script, StdAssertions {
+  using PoolIdLibrary for PoolKey;
+
+  /// @notice The V4 PoolManager on mainnet
+  IPoolManager public constant POOL_MANAGER = IPoolManager(0x000000000004444c5dc75cB358380D2e3dE08A90);
+
+  /// @notice GovernorBravo contract for submitting proposals
+  IGovernorBravo internal constant GOVERNOR_BRAVO = IGovernorBravo(0x408ED6354d4973f66138C91495F2f2FCbd8724C3);
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      FEE CONFIGURATION
+  // ═══════════════════════════════════════════════════════════════
+  //
+  // Fee ratios match V3 mainnet configuration:
+  // - Default ratio: 1/4 of LP fee
+  // - 0.30% and 1.00% tiers: 1/6 of LP fee
+  //
+  // V4 protocol fees are in pips (1/1_000_000). Max is 1000 pips (0.1%) per direction.
+
+  /// @notice Default protocol fee for unknown tiers (1/4 of a typical 0.30% tier = 750 pips)
+  /// @dev This is a fallback; most pools should match a known tier override
+  uint24 public constant DEFAULT_PROTOCOL_FEE = 750;
+
+  // Fee tier overrides (LP fee tier → protocol fee in pips)
+  // Ratio: protocol_fee = lp_fee / N, where N is 4 (default) or 6 (high fee tiers)
+  uint24 public constant TIER_8_FEE = 2; // 0.0008% / 4 = 0.0002% = 2 pips
+  uint24 public constant TIER_10_FEE = 3; // 0.001% / 4 = 0.00025% ≈ 3 pips
+  uint24 public constant TIER_45_FEE = 11; // 0.0045% / 4 = 0.001125% ≈ 11 pips
+  uint24 public constant TIER_100_FEE = 25; // 0.01% / 4 = 0.0025% = 25 pips
+  uint24 public constant TIER_500_FEE = 125; // 0.05% / 4 = 0.0125% = 125 pips
+  uint24 public constant TIER_3000_FEE = 500; // 0.30% / 6 = 0.05% = 500 pips
+  uint24 public constant TIER_10000_FEE = 1000; // 1.00% / 6 = 0.167% → capped at 1000 pips (0.1%)
+
+  string internal constant PROPOSAL_DESCRIPTION = "# V4 Fee Switch Proposal\n\n"
+    "This proposal activates protocol fees on Uniswap V4, matching the fee structure "
+    "established for V3 in the UNIfication proposal.\n\n"
+    "## Actions\n\n"
+    "1. Set the V4FeeAdapter as the protocol fee controller on the V4 PoolManager\n"
+    "2. Set a default protocol fee for pools without specific tier overrides\n"
+    "3. Configure tier-based protocol fees matching V3 ratios\n"
+    "4. Apply fees to initial set of high-volume V4 pools\n\n"
+    "## Fee Structure\n\n"
+    "Protocol fees are calculated as a fraction of the LP fee tier:\n"
+    "- **1/4 ratio** for low-fee tiers (<=0.05%)\n"
+    "- **1/6 ratio** for high-fee tiers (0.30% and 1.00%)\n\n"
+    "| LP Fee Tier | Ratio | Protocol Fee |\n"
+    "| ----------- | ----- | ------------ |\n"
+    "| 0.0008% | 1/4 | 0.0002% (2 pips) |\n"
+    "| 0.001% | 1/4 | 0.00025% (3 pips) |\n"
+    "| 0.0045% | 1/4 | 0.00113% (11 pips) |\n"
+    "| 0.01% | 1/4 | 0.0025% (25 pips) |\n"
+    "| 0.05% | 1/4 | 0.0125% (125 pips) |\n"
+    "| 0.30% | 1/6 | 0.05% (500 pips) |\n"
+    "| 1.00% | 1/6 | 0.10% (1000 pips)* |\n\n"
+    "*Capped at V4 maximum of 0.1% (1000 pips)\n\n"
+    "All protocol fees flow to the TokenJar and can only be released via UNI burn.\n";
+
+  function setUp() public {}
+
+  /// @notice Generate proposal actions for the V4 fee switch
+  /// @param adapter The deployed V4FeeAdapter
+  /// @param poolsToActivate Array of pool keys to activate fees on
+  function generateActions(V4FeeAdapter adapter, PoolKey[] memory poolsToActivate)
+    public
+    view
+    returns (ProposalAction[] memory actions)
+  {
+    // Calculate number of actions:
+    // 1. Set protocol fee controller
+    // 2. Set default fee
+    // 3-9. Set fee tier overrides (7 tiers)
+    // 10. Batch apply fees to pools
+    uint256 numActions = 10;
+    actions = new ProposalAction[](numActions);
+
+    // Action 0: Set the V4FeeAdapter as the protocol fee controller
+    actions[0] = ProposalAction({
+      target: address(POOL_MANAGER),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(IProtocolFees.setProtocolFeeController, (address(adapter)))
+    });
+
+    // Action 1: Set default protocol fee
+    actions[1] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setDefaultFee, (DEFAULT_PROTOCOL_FEE))
+    });
+
+    // Action 2-8: Set fee tier overrides
+    actions[2] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (8, TIER_8_FEE))
+    });
+
+    actions[3] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (10, TIER_10_FEE))
+    });
+
+    actions[4] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (45, TIER_45_FEE))
+    });
+
+    actions[5] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (100, TIER_100_FEE))
+    });
+
+    actions[6] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (500, TIER_500_FEE))
+    });
+
+    actions[7] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (3000, TIER_3000_FEE))
+    });
+
+    actions[8] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.setFeeTierOverride, (10000, TIER_10000_FEE))
+    });
+
+    // Action 9: Batch apply fees to initial pools
+    actions[9] = ProposalAction({
+      target: address(adapter),
+      value: 0,
+      signature: "",
+      data: abi.encodeCall(adapter.batchApplyFees, (poolsToActivate))
+    });
+  }
+
+  /// @notice Run the proposal simulation with prank (for testing)
+  /// @param adapter The deployed V4FeeAdapter
+  /// @param poolsToActivate Array of pool keys to activate fees on
+  /// @param executor The address executing the proposal (e.g., timelock)
+  function runPranked(V4FeeAdapter adapter, PoolKey[] memory poolsToActivate, address executor) public {
+    vm.startPrank(executor);
+    ProposalAction[] memory actions = generateActions(adapter, poolsToActivate);
+    for (uint256 i = 0; i < actions.length; i++) {
+      ProposalAction memory action = actions[i];
+      (bool success,) = action.target.call{value: action.value}(action.data);
+      require(success, string.concat("Action ", vm.toString(i), " failed"));
+    }
+    vm.stopPrank();
+  }
+
+  /// @notice Submit the proposal to GovernorBravo
+  /// @param adapter The deployed V4FeeAdapter
+  /// @param poolsToActivate Array of pool keys to activate fees on
+  function run(V4FeeAdapter adapter, PoolKey[] memory poolsToActivate) public {
+    vm.startBroadcast();
+
+    ProposalAction[] memory actions = generateActions(adapter, poolsToActivate);
+
+    console2.log("Calldata details:");
+    for (uint256 i = 0; i < actions.length; i++) {
+      ProposalAction memory action = actions[i];
+      assertTrue(action.target != address(0));
+      console2.log("Action #", i);
+      console2.log("Target", action.target);
+      console2.log("Value", action.value);
+      console2.log("Signature");
+      console2.log(action.signature);
+      console2.log("Calldata", i);
+      console2.logBytes(action.data);
+      console2.log("--------------------------------");
+    }
+
+    console2.log("Description:");
+    console2.log(PROPOSAL_DESCRIPTION);
+
+    // Prepare GovernorBravo propose() parameters
+    address[] memory targets = new address[](actions.length);
+    uint256[] memory values = new uint256[](actions.length);
+    string[] memory signatures = new string[](actions.length);
+    bytes[] memory calldatas = new bytes[](actions.length);
+    for (uint256 i = 0; i < actions.length; i++) {
+      ProposalAction memory action = actions[i];
+      targets[i] = action.target;
+      values[i] = action.value;
+      signatures[i] = action.signature;
+      calldatas[i] = action.data;
+    }
+
+    bytes memory proposalCalldata = abi.encodeCall(
+      IGovernorBravo.propose, (targets, values, signatures, calldatas, PROPOSAL_DESCRIPTION)
+    );
+    console2.log("GovernorBravo.propose() Calldata:");
+    console2.logBytes(proposalCalldata);
+
+    GOVERNOR_BRAVO.propose(targets, values, signatures, calldatas, PROPOSAL_DESCRIPTION);
+    vm.stopBroadcast();
+  }
+}
+
+interface IGovernorBravo {
+  function propose(
+    address[] memory targets,
+    uint256[] memory values,
+    string[] memory signatures,
+    bytes[] memory calldatas,
+    string memory description
+  ) external returns (uint256);
+}

--- a/script/06_DeployV4Mainnet.s.sol
+++ b/script/06_DeployV4Mainnet.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {console2} from "forge-std/console2.sol";
+import {Script} from "forge-std/Script.sol";
+import {V4MainnetDeployer} from "./deployers/V4MainnetDeployer.sol";
+
+/// @title DeployV4Mainnet
+/// @notice Deployment script for V4FeeAdapter on Ethereum mainnet
+contract DeployV4Mainnet is Script {
+  function setUp() public {}
+
+  function run() public {
+    require(block.chainid == 1, "Not mainnet");
+
+    vm.startBroadcast();
+
+    V4MainnetDeployer deployer = new V4MainnetDeployer{salt: bytes32(uint256(2))}();
+    console2.log("Deployed V4MainnetDeployer at:", address(deployer));
+    console2.log("V4_FEE_ADAPTER at:", address(deployer.V4_FEE_ADAPTER()));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/07_DeployV4Unichain.s.sol
+++ b/script/07_DeployV4Unichain.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {console2} from "forge-std/console2.sol";
+import {Script} from "forge-std/Script.sol";
+import {V4UnichainDeployer} from "./deployers/V4UnichainDeployer.sol";
+
+/// @title DeployV4Unichain
+/// @notice Deployment script for V4FeeAdapter on Unichain
+contract DeployV4Unichain is Script {
+  function setUp() public {}
+
+  function run() public {
+    require(block.chainid == 130, "Not Unichain");
+
+    vm.startBroadcast();
+
+    V4UnichainDeployer deployer = new V4UnichainDeployer{salt: bytes32(uint256(2))}();
+    console2.log("Deployed V4UnichainDeployer at:", address(deployer));
+    console2.log("V4_FEE_ADAPTER at:", address(deployer.V4_FEE_ADAPTER()));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/deployers/V4MainnetDeployer.sol
+++ b/script/deployers/V4MainnetDeployer.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import {V4FeeAdapter} from "../../src/feeAdapters/V4FeeAdapter.sol";
+import {IV4FeeAdapter} from "../../src/interfaces/IV4FeeAdapter.sol";
+import {IOwned} from "../../src/interfaces/base/IOwned.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+
+/// @title V4MainnetDeployer
+/// @notice Deployment contract for V4FeeAdapter on Ethereum mainnet
+/// @dev Deploys V4FeeAdapter configured to use the existing TokenJar.
+///      Uses CREATE2 for deterministic deployment addresses.
+/// @custom:security-contact security@uniswap.org
+contract V4MainnetDeployer {
+  /// @notice The deployed V4FeeAdapter contract instance
+  IV4FeeAdapter public immutable V4_FEE_ADAPTER;
+
+  /// @notice The Uniswap V4 PoolManager on mainnet
+  IPoolManager public constant POOL_MANAGER = IPoolManager(0x000000000004444c5dc75cB358380D2e3dE08A90);
+
+  /// @notice The UNI governance timelock on mainnet
+  address public constant TIMELOCK = 0x1a9C8182C09F50C8318d769245beA52c32BE35BC;
+
+  /// @notice The existing TokenJar deployed by MainnetDeployer
+  address public constant TOKEN_JAR = 0xf38521f130fcCF29dB1961597bc5d2B60F995f85;
+
+  /// @dev CREATE2 salt for deterministic V4FeeAdapter deployment
+  bytes32 constant SALT_V4_FEE_ADAPTER = bytes32(uint256(1));
+
+  /// @notice Deploys the V4FeeAdapter configured for mainnet
+  /// @dev Performs the following:
+  ///      1. Deploy V4FeeAdapter with timelock as feeSetter and no initial default fee
+  ///      2. Transfer ownership to timelock
+  ///
+  ///      The V4FeeAdapter is deployed with:
+  ///      - POOL_MANAGER: Mainnet V4 PoolManager
+  ///      - TOKEN_JAR: Existing TokenJar
+  ///      - feeSetter: Timelock (same as owner)
+  ///      - defaultFee: 0 (to be set via governance proposal)
+  constructor() {
+    /// 1. Deploy the V4FeeAdapter
+    V4_FEE_ADAPTER = new V4FeeAdapter{salt: SALT_V4_FEE_ADAPTER}(
+      address(POOL_MANAGER),
+      TOKEN_JAR,
+      TIMELOCK, // feeSetter = timelock
+      0 // defaultFee = 0 (to be configured via proposal)
+    );
+
+    /// 2. Transfer ownership to the timelock
+    IOwned(address(V4_FEE_ADAPTER)).transferOwnership(TIMELOCK);
+  }
+}

--- a/script/deployers/V4UnichainDeployer.sol
+++ b/script/deployers/V4UnichainDeployer.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import {V4FeeAdapter} from "../../src/feeAdapters/V4FeeAdapter.sol";
+import {IV4FeeAdapter} from "../../src/interfaces/IV4FeeAdapter.sol";
+import {IOwned} from "../../src/interfaces/base/IOwned.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+
+/// @title V4UnichainDeployer
+/// @notice Deployment contract for V4FeeAdapter on Unichain
+/// @dev Deploys V4FeeAdapter configured to use the existing TokenJar.
+///      Uses CREATE2 for deterministic deployment addresses.
+/// @custom:security-contact security@uniswap.org
+contract V4UnichainDeployer {
+  /// @notice The deployed V4FeeAdapter contract instance
+  IV4FeeAdapter public immutable V4_FEE_ADAPTER;
+
+  /// @notice The Uniswap V4 PoolManager on Unichain
+  IPoolManager public constant POOL_MANAGER = IPoolManager(0x1F98400000000000000000000000000000000004);
+
+  /// @notice UNI Timelock alias address on Unichain
+  /// @dev Calculated from the aliasing scheme defined at
+  ///      https://docs.optimism.io/concepts/stack/differences#address-aliasing
+  ///      targeting 0x1a9C8182C09F50C8318d769245beA52c32BE35BC on mainnet
+  address public constant OWNER = 0x2BAD8182C09F50c8318d769245beA52C32Be46CD;
+
+  /// @notice The existing TokenJar deployed by UnichainDeployer
+  address public constant TOKEN_JAR = 0xD576BDF6b560079a4c204f7644e556DbB19140b5;
+
+  /// @dev CREATE2 salt for deterministic V4FeeAdapter deployment
+  bytes32 constant SALT_V4_FEE_ADAPTER = bytes32(uint256(1));
+
+  /// @notice Deploys the V4FeeAdapter configured for Unichain
+  /// @dev Performs the following:
+  ///      1. Deploy V4FeeAdapter with OWNER as feeSetter and no initial default fee
+  ///      2. Transfer ownership to timelock alias
+  ///
+  ///      The V4FeeAdapter is deployed with:
+  ///      - POOL_MANAGER: Unichain V4 PoolManager
+  ///      - TOKEN_JAR: Existing TokenJar
+  ///      - feeSetter: Timelock alias (same as owner)
+  ///      - defaultFee: 0 (to be set via governance or admin action)
+  constructor() {
+    /// 1. Deploy the V4FeeAdapter
+    V4_FEE_ADAPTER = new V4FeeAdapter{salt: SALT_V4_FEE_ADAPTER}(
+      address(POOL_MANAGER),
+      TOKEN_JAR,
+      OWNER, // feeSetter = timelock alias
+      0 // defaultFee = 0 (to be configured separately)
+    );
+
+    /// 2. Transfer ownership to the timelock alias
+    IOwned(address(V4_FEE_ADAPTER)).transferOwnership(OWNER);
+  }
+}

--- a/src/feeAdapters/V4FeeAdapter.sol
+++ b/src/feeAdapters/V4FeeAdapter.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {Owned} from "solmate/src/auth/Owned.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {ProtocolFeeLibrary} from "v4-core/libraries/ProtocolFeeLibrary.sol";
+import {IV4FeeAdapter} from "../interfaces/IV4FeeAdapter.sol";
+
+/// @title V4FeeAdapter
+/// @notice A protocol fee controller for Uniswap V4 with tiered fee resolution
+/// @dev Resolves fees using a waterfall pattern: pool override → fee tier → default
+///      This contract must be set as the protocolFeeController on the PoolManager
+///
+///      Storage encoding:
+///      - 0 in storage = "not set" (continue waterfall)
+///      - ZERO_FEE_SENTINEL in storage = "explicitly set to zero" (fees disabled)
+///      - Any other value = that actual fee
+///
+/// @custom:security-contact security@uniswap.org
+contract V4FeeAdapter is IV4FeeAdapter, Owned {
+  using PoolIdLibrary for PoolKey;
+
+  /// @notice Sentinel value stored to represent an explicit zero fee (disabled)
+  /// @dev We use type(uint24).max because 0 in storage means "not set" (mapping default)
+  uint24 public constant ZERO_FEE_SENTINEL = type(uint24).max;
+
+  /// @inheritdoc IV4FeeAdapter
+  IPoolManager public immutable POOL_MANAGER;
+
+  /// @inheritdoc IV4FeeAdapter
+  address public immutable TOKEN_JAR;
+
+  /// @inheritdoc IV4FeeAdapter
+  address public feeSetter;
+
+  /// @inheritdoc IV4FeeAdapter
+  uint24 public defaultFee;
+
+  /// @inheritdoc IV4FeeAdapter
+  mapping(uint24 lpFee => uint24 protocolFee) public feeTierOverrides;
+
+  /// @inheritdoc IV4FeeAdapter
+  mapping(PoolId poolId => uint24 protocolFee) public poolOverrides;
+
+  /// @notice Ensures only the fee setter can call restricted functions
+  modifier onlyFeeSetter() {
+    if (msg.sender != feeSetter) revert Unauthorized();
+    _;
+  }
+
+  /// @param _poolManager The Uniswap V4 PoolManager contract
+  /// @param _tokenJar The address where collected fees are sent
+  /// @param _feeSetter The address authorized to set fees
+  /// @param _defaultFee The default protocol fee (pass ZERO_FEE_SENTINEL to explicitly disable,
+  ///        or leave as 0 for "not set")
+  constructor(address _poolManager, address _tokenJar, address _feeSetter, uint24 _defaultFee) Owned(msg.sender) {
+    if (_defaultFee != 0) _validateFee(_defaultFee);
+    POOL_MANAGER = IPoolManager(_poolManager);
+    TOKEN_JAR = _tokenJar;
+    feeSetter = _feeSetter;
+    defaultFee = _defaultFee;
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  /// @dev Returns the fee packed for BOTH swap directions (symmetric fee).
+  ///      V4 protocol fees are a uint24 where lower 12 bits = zeroForOne fee,
+  ///      upper 12 bits = oneForZero fee. We apply the same fee to both directions.
+  function getFee(PoolKey memory key) public view returns (uint24 fee) {
+    uint24 stored;
+
+    // 1. Pool override (most specific)
+    stored = poolOverrides[key.toId()];
+    if (stored != 0) return _packFee(_decodeFee(stored));
+
+    // 2. Fee tier override
+    stored = feeTierOverrides[key.fee];
+    if (stored != 0) return _packFee(_decodeFee(stored));
+
+    // 3. Default fee
+    stored = defaultFee;
+    if (stored != 0) return _packFee(_decodeFee(stored));
+
+    // Nothing set → no protocol fee
+    return 0;
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function applyFee(PoolKey memory key) external {
+    POOL_MANAGER.setProtocolFee(key, getFee(key));
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function batchApplyFees(PoolKey[] calldata keys) external {
+    uint256 length = keys.length;
+    for (uint256 i; i < length; ++i) {
+      POOL_MANAGER.setProtocolFee(keys[i], getFee(keys[i]));
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                           SETTERS
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @inheritdoc IV4FeeAdapter
+  function setDefaultFee(uint24 fee) external onlyFeeSetter {
+    _validateFee(fee);
+    defaultFee = _encodeFee(fee);
+    emit DefaultFeeUpdated(fee);
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function setFeeTierOverride(uint24 lpFee, uint24 protocolFee) external onlyFeeSetter {
+    _validateFee(protocolFee);
+    feeTierOverrides[lpFee] = _encodeFee(protocolFee);
+    emit FeeTierOverrideUpdated(lpFee, protocolFee);
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function setPoolOverride(PoolId poolId, uint24 protocolFee) external onlyFeeSetter {
+    _validateFee(protocolFee);
+    poolOverrides[poolId] = _encodeFee(protocolFee);
+    emit PoolOverrideUpdated(poolId, protocolFee);
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function clearFeeTierOverride(uint24 lpFee) external onlyFeeSetter {
+    delete feeTierOverrides[lpFee];
+    emit FeeTierOverrideUpdated(lpFee, 0);
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function clearPoolOverride(PoolId poolId) external onlyFeeSetter {
+    delete poolOverrides[poolId];
+    emit PoolOverrideUpdated(poolId, 0);
+  }
+
+  /// @inheritdoc IV4FeeAdapter
+  function setFeeSetter(address newFeeSetter) external onlyOwner {
+    feeSetter = newFeeSetter;
+    emit FeeSetterUpdated(newFeeSetter);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                       FEE COLLECTION
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @inheritdoc IV4FeeAdapter
+  function collectProtocolFees(Currency currency, uint256 amount)
+    external
+    onlyOwner
+    returns (uint256 amountCollected)
+  {
+    return POOL_MANAGER.collectProtocolFees(TOKEN_JAR, currency, amount);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                         INTERNAL
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @notice Validates that a protocol fee is within bounds
+  /// @param fee The fee to validate in pips (single direction, not packed)
+  function _validateFee(uint24 fee) internal pure {
+    // 0 is valid (disables protocol fee)
+    // Otherwise must be <= MAX_PROTOCOL_FEE (1000 pips = 0.1%)
+    if (fee != 0 && fee > ProtocolFeeLibrary.MAX_PROTOCOL_FEE) {
+      revert ProtocolFeeTooLarge(fee);
+    }
+  }
+
+  /// @notice Encodes a fee for storage
+  /// @dev Converts 0 to ZERO_FEE_SENTINEL so we can distinguish from "not set"
+  /// @param fee The actual fee value
+  /// @return The encoded value to store
+  function _encodeFee(uint24 fee) internal pure returns (uint24) {
+    return fee == 0 ? ZERO_FEE_SENTINEL : fee;
+  }
+
+  /// @notice Decodes a fee from storage
+  /// @dev Converts ZERO_FEE_SENTINEL back to 0
+  /// @param stored The value from storage
+  /// @return The actual fee value
+  function _decodeFee(uint24 stored) internal pure returns (uint24) {
+    return stored == ZERO_FEE_SENTINEL ? 0 : stored;
+  }
+
+  /// @notice Packs a single-direction fee into the V4 protocol fee format for both directions
+  /// @dev V4 protocol fee is a uint24: lower 12 bits = zeroForOne, upper 12 bits = oneForZero
+  /// @param fee The fee in pips (0-1000 range for single direction)
+  /// @return The packed fee value for symmetric application to both swap directions
+  function _packFee(uint24 fee) internal pure returns (uint24) {
+    // Pack fee into both directions: (oneForZero << 12) | zeroForOne
+    return (fee << 12) | fee;
+  }
+}

--- a/src/interfaces/IV4FeeAdapter.sol
+++ b/src/interfaces/IV4FeeAdapter.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId} from "v4-core/types/PoolId.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+
+/// @title IV4FeeAdapter
+/// @notice Interface for the Uniswap V4 protocol fee controller with tiered fee resolution
+/// @dev Resolves fees using a waterfall pattern: pool override → fee tier → default
+interface IV4FeeAdapter {
+  /// @notice Thrown when an unauthorized address attempts to call a restricted function
+  error Unauthorized();
+
+  /// @notice Thrown when the provided protocol fee exceeds the maximum allowed
+  error ProtocolFeeTooLarge(uint24 fee);
+
+  /// @notice Emitted when the default protocol fee is updated
+  /// @param newFee The new default fee value
+  event DefaultFeeUpdated(uint24 newFee);
+
+  /// @notice Emitted when a fee tier override is updated
+  /// @param lpFee The LP fee tier that was updated
+  /// @param protocolFee The new protocol fee for this tier
+  event FeeTierOverrideUpdated(uint24 indexed lpFee, uint24 protocolFee);
+
+  /// @notice Emitted when a pool-specific override is updated
+  /// @param poolId The pool ID that was updated
+  /// @param protocolFee The new protocol fee for this pool
+  event PoolOverrideUpdated(PoolId indexed poolId, uint24 protocolFee);
+
+  /// @notice Emitted when the fee setter address is updated
+  /// @param newFeeSetter The new fee setter address
+  event FeeSetterUpdated(address indexed newFeeSetter);
+
+  /// @notice The Uniswap V4 PoolManager contract
+  function POOL_MANAGER() external view returns (IPoolManager);
+
+  /// @notice The address where collected fees are sent
+  function TOKEN_JAR() external view returns (address);
+
+  /// @notice Sentinel value stored to represent an explicit zero fee (disabled)
+  /// @dev In storage: 0 = "not set", ZERO_FEE_SENTINEL = "explicitly zero", other = actual fee
+  function ZERO_FEE_SENTINEL() external pure returns (uint24);
+
+  /// @notice The default protocol fee applied when no overrides match
+  function defaultFee() external view returns (uint24);
+
+  /// @notice Returns the fee tier override for a given LP fee (raw storage value)
+  /// @param lpFee The LP fee tier to query
+  /// @return protocolFee The stored value (0 = not set, ZERO_FEE_SENTINEL = zero fee, other = actual fee)
+  function feeTierOverrides(uint24 lpFee) external view returns (uint24 protocolFee);
+
+  /// @notice Returns the pool-specific override for a given pool (raw storage value)
+  /// @param poolId The pool ID to query
+  /// @return protocolFee The stored value (0 = not set, ZERO_FEE_SENTINEL = zero fee, other = actual fee)
+  function poolOverrides(PoolId poolId) external view returns (uint24 protocolFee);
+
+  /// @notice The authorized address to set fee values
+  function feeSetter() external view returns (address);
+
+  /// @notice Resolves the protocol fee for a pool using the waterfall pattern
+  /// @dev Returns a packed fee for BOTH swap directions (symmetric).
+  ///      V4 protocol fee format: lower 12 bits = zeroForOne, upper 12 bits = oneForZero.
+  ///      Example: 500 pips stored → returns (500 << 12) | 500 = 2048500
+  /// @param key The pool key to resolve fees for
+  /// @return fee The resolved protocol fee packed for both directions (0 if nothing set)
+  function getFee(PoolKey memory key) external view returns (uint24 fee);
+
+  /// @notice Apply the resolved fee to a pool on the PoolManager
+  /// @param key The pool to update
+  function applyFee(PoolKey memory key) external;
+
+  /// @notice Batch apply fees to multiple pools
+  /// @param keys Array of pool keys to update
+  function batchApplyFees(PoolKey[] calldata keys) external;
+
+  /// @notice Sets the default protocol fee
+  /// @dev Only callable by feeSetter. Max allowed is 1000 pips (0.1%).
+  ///      The fee will be applied symmetrically to both swap directions.
+  /// @param fee The new default fee value in pips (1-1000 range, or 0 to disable)
+  function setDefaultFee(uint24 fee) external;
+
+  /// @notice Sets a fee tier override
+  /// @dev Only callable by feeSetter. Max allowed is 1000 pips (0.1%).
+  ///      Use 0 to explicitly disable fees for this tier (distinct from clearing).
+  ///      The fee will be applied symmetrically to both swap directions.
+  /// @param lpFee The LP fee tier to set an override for
+  /// @param protocolFee The protocol fee in pips (0 = disabled, 1-1000 = fee rate)
+  function setFeeTierOverride(uint24 lpFee, uint24 protocolFee) external;
+
+  /// @notice Sets a pool-specific override
+  /// @dev Only callable by feeSetter. Max allowed is 1000 pips (0.1%).
+  ///      Use 0 to explicitly disable fees for this pool (distinct from clearing).
+  ///      The fee will be applied symmetrically to both swap directions.
+  /// @param poolId The pool ID to set an override for
+  /// @param protocolFee The protocol fee in pips (0 = disabled, 1-1000 = fee rate)
+  function setPoolOverride(PoolId poolId, uint24 protocolFee) external;
+
+  /// @notice Clears a fee tier override (reverts to next level in waterfall)
+  /// @dev Only callable by feeSetter
+  /// @param lpFee The LP fee tier to clear
+  function clearFeeTierOverride(uint24 lpFee) external;
+
+  /// @notice Clears a pool-specific override (reverts to next level in waterfall)
+  /// @dev Only callable by feeSetter
+  /// @param poolId The pool ID to clear
+  function clearPoolOverride(PoolId poolId) external;
+
+  /// @notice Sets a new fee setter address
+  /// @dev Only callable by owner
+  /// @param newFeeSetter The new address authorized to set fees
+  function setFeeSetter(address newFeeSetter) external;
+
+  /// @notice Collects protocol fees from the PoolManager to the TOKEN_JAR
+  /// @dev Only callable by owner
+  /// @param currency The currency to collect
+  /// @param amount The amount to collect (0 for all available)
+  /// @return amountCollected The amount actually collected
+  function collectProtocolFees(Currency currency, uint256 amount)
+    external
+    returns (uint256 amountCollected);
+}

--- a/test/ProtocolFees.fork.t.sol
+++ b/test/ProtocolFees.fork.t.sol
@@ -51,8 +51,11 @@ contract ProtocolFeesForkTest is Test {
   // v2 pair: WETH / USDC
   IUniswapV2Pair pair;
 
+  // Fork from block before the unification proposal was executed
+  uint256 constant FORK_BLOCK = 24_106_377;
+
   function setUp() public {
-    vm.createSelectFork("mainnet");
+    vm.createSelectFork("mainnet", FORK_BLOCK);
     factory = IUniswapV3Factory(0x1F98431c8aD98523631AE4a59f267346ea31F984);
     v2Factory = IUniswapV2Factory(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
     v2Router = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);

--- a/test/UNIVesting.fork.t.sol
+++ b/test/UNIVesting.fork.t.sol
@@ -23,8 +23,11 @@ contract UNIVestingForkTest is Test {
   uint256 constant MONTHS_PER_QUARTER = 3;
   uint256 constant QUARTERLY_AMOUNT = 5_000_000 ether;
 
+  // Fork from block before the unification proposal was executed
+  uint256 constant FORK_BLOCK = 24_106_377;
+
   function setUp() public {
-    vm.createSelectFork("mainnet");
+    vm.createSelectFork("mainnet", FORK_BLOCK);
     factory = IUniswapV3Factory(0x1F98431c8aD98523631AE4a59f267346ea31F984);
     owner = factory.owner();
 

--- a/test/V4FeeAdapter.t.sol
+++ b/test/V4FeeAdapter.t.sol
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.29;
+
+import {ProtocolFeesTestBase} from "./utils/ProtocolFeesTestBase.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {ProtocolFeeLibrary} from "v4-core/libraries/ProtocolFeeLibrary.sol";
+import {MockPoolManager} from "./mocks/MockPoolManager.sol";
+import {V4FeeAdapter, IV4FeeAdapter} from "../src/feeAdapters/V4FeeAdapter.sol";
+
+contract V4FeeAdapterTest is ProtocolFeesTestBase {
+  using PoolIdLibrary for PoolKey;
+
+  MockPoolManager public poolManager;
+  V4FeeAdapter public feeAdapter;
+
+  // Common fee values for testing (single-direction pips)
+  // V4 protocol fees are in pips (1/1_000_000), max 1000 per direction
+  // The adapter stores single-direction values and packs them symmetrically on retrieval
+  uint24 constant DEFAULT_FEE = 500; // 0.05%
+  uint24 constant TIER_FEE_3000 = 300; // 0.03%
+  uint24 constant TIER_FEE_500 = 200; // 0.02%
+  uint24 constant POOL_OVERRIDE_FEE = 100; // 0.01%
+  uint24 constant MAX_VALID_FEE = 1000; // Max valid per direction: 0.1%
+
+  /// @notice Packs a single-direction fee into both directions (matches V4FeeAdapter._packFee)
+  function _packFee(uint24 fee) internal pure returns (uint24) {
+    return (fee << 12) | fee;
+  }
+
+  // Test pool keys
+  PoolKey pool3000;
+  PoolKey pool500;
+  PoolKey poolCustom;
+
+  function setUp() public override {
+    super.setUp();
+
+    // Deploy mock pool manager with owner as the owner
+    vm.startPrank(owner);
+    poolManager = new MockPoolManager(owner);
+
+    // Deploy fee adapter with no default (0 = not set)
+    feeAdapter = new V4FeeAdapter(
+      address(poolManager),
+      address(tokenJar),
+      owner, // feeSetter
+      0 // no default initially
+    );
+
+    // Set fee adapter as the protocol fee controller
+    poolManager.setProtocolFeeController(address(feeAdapter));
+    vm.stopPrank();
+
+    // Create test pool keys with different LP fee tiers
+    pool3000 = PoolKey({
+      currency0: Currency.wrap(address(mockToken)),
+      currency1: Currency.wrap(address(mockToken1)),
+      fee: 3000, // 0.30% LP fee
+      tickSpacing: 60,
+      hooks: IHooks(address(0))
+    });
+
+    pool500 = PoolKey({
+      currency0: Currency.wrap(address(mockToken)),
+      currency1: Currency.wrap(address(mockToken1)),
+      fee: 500, // 0.05% LP fee
+      tickSpacing: 10,
+      hooks: IHooks(address(0))
+    });
+
+    poolCustom = PoolKey({
+      currency0: Currency.wrap(address(mockToken)),
+      currency1: Currency.wrap(address(mockToken1)),
+      fee: 10000, // 1% LP fee
+      tickSpacing: 200,
+      hooks: IHooks(address(0))
+    });
+
+    // Initialize pools in mock manager
+    poolManager.mockInitialize(pool3000);
+    poolManager.mockInitialize(pool500);
+    poolManager.mockInitialize(poolCustom);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      CONSTRUCTOR TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_constructor_setsPoolManager() public view {
+    assertEq(address(feeAdapter.POOL_MANAGER()), address(poolManager));
+  }
+
+  function test_constructor_setsTokenJar() public view {
+    assertEq(feeAdapter.TOKEN_JAR(), address(tokenJar));
+  }
+
+  function test_constructor_setsFeeSetter() public view {
+    assertEq(feeAdapter.feeSetter(), owner);
+  }
+
+  function test_constructor_setsDefaultFee() public view {
+    assertEq(feeAdapter.defaultFee(), 0); // 0 = not set
+  }
+
+  function test_constructor_revertsWithInvalidDefaultFee() public {
+    uint24 invalidFee = 2000; // > MAX_PROTOCOL_FEE
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, invalidFee));
+    new V4FeeAdapter(address(poolManager), address(tokenJar), owner, invalidFee);
+  }
+
+  function test_constructor_acceptsZeroDefault() public {
+    vm.prank(owner);
+    V4FeeAdapter adapter = new V4FeeAdapter(address(poolManager), address(tokenJar), owner, 0);
+    assertEq(adapter.defaultFee(), 0);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    WATERFALL RESOLUTION TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_getFee_returnsZero_whenNothingSet() public view {
+    // Nothing configured, should return 0
+    assertEq(feeAdapter.getFee(pool3000), 0);
+  }
+
+  function test_getFee_returnsDefault_whenOnlyDefaultSet() public {
+    vm.prank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+
+    assertEq(feeAdapter.getFee(pool3000), _packFee(DEFAULT_FEE));
+    assertEq(feeAdapter.getFee(pool500), _packFee(DEFAULT_FEE));
+    assertEq(feeAdapter.getFee(poolCustom), _packFee(DEFAULT_FEE));
+  }
+
+  function test_getFee_returnsFeeTier_overDefault() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    vm.stopPrank();
+
+    // pool3000 should use tier override
+    assertEq(feeAdapter.getFee(pool3000), _packFee(TIER_FEE_3000));
+    // pool500 should fall through to default
+    assertEq(feeAdapter.getFee(pool500), _packFee(DEFAULT_FEE));
+  }
+
+  function test_getFee_returnsPoolOverride_overFeeTier() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+    vm.stopPrank();
+
+    // pool3000 should use pool override (highest priority)
+    assertEq(feeAdapter.getFee(pool3000), _packFee(POOL_OVERRIDE_FEE));
+    // pool500 should fall through to default
+    assertEq(feeAdapter.getFee(pool500), _packFee(DEFAULT_FEE));
+  }
+
+  function test_getFee_fullWaterfall() public {
+    vm.startPrank(owner);
+    // Set all levels
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    feeAdapter.setFeeTierOverride(500, TIER_FEE_500);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+    vm.stopPrank();
+
+    // pool3000: has pool override → uses pool override
+    assertEq(feeAdapter.getFee(pool3000), _packFee(POOL_OVERRIDE_FEE));
+    // pool500: has tier override, no pool override → uses tier override
+    assertEq(feeAdapter.getFee(pool500), _packFee(TIER_FEE_500));
+    // poolCustom: no pool or tier override → uses default
+    assertEq(feeAdapter.getFee(poolCustom), _packFee(DEFAULT_FEE));
+  }
+
+  function test_getFee_poolOverrideZero_disablesFee() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    // Explicitly set pool override to 0 (disabled)
+    feeAdapter.setPoolOverride(pool3000.toId(), 0);
+    vm.stopPrank();
+
+    // pool3000 should use pool override of 0 (fees disabled)
+    assertEq(feeAdapter.getFee(pool3000), 0);
+  }
+
+  function test_getFee_feeTierZero_disablesFee() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    // Explicitly set tier override to 0
+    feeAdapter.setFeeTierOverride(3000, 0);
+    vm.stopPrank();
+
+    // pool3000 should use tier override of 0 (no packing for zero)
+    assertEq(feeAdapter.getFee(pool3000), 0);
+    // pool500 should fall through to default
+    assertEq(feeAdapter.getFee(pool500), _packFee(DEFAULT_FEE));
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      APPLY FEE TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_applyFee_setsProtocolFeeOnPoolManager() public {
+    vm.prank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+
+    feeAdapter.applyFee(pool3000);
+
+    assertEq(poolManager.getProtocolFee(pool3000.toId()), _packFee(DEFAULT_FEE));
+  }
+
+  function test_applyFee_respectsWaterfall() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    feeAdapter.setPoolOverride(pool500.toId(), POOL_OVERRIDE_FEE);
+    vm.stopPrank();
+
+    feeAdapter.applyFee(pool3000);
+    feeAdapter.applyFee(pool500);
+    feeAdapter.applyFee(poolCustom);
+
+    assertEq(poolManager.getProtocolFee(pool3000.toId()), _packFee(TIER_FEE_3000));
+    assertEq(poolManager.getProtocolFee(pool500.toId()), _packFee(POOL_OVERRIDE_FEE));
+    assertEq(poolManager.getProtocolFee(poolCustom.toId()), _packFee(DEFAULT_FEE));
+  }
+
+  function test_batchApplyFees_setsMultiplePoolFees() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    feeAdapter.setPoolOverride(pool500.toId(), POOL_OVERRIDE_FEE);
+    vm.stopPrank();
+
+    PoolKey[] memory keys = new PoolKey[](3);
+    keys[0] = pool3000;
+    keys[1] = pool500;
+    keys[2] = poolCustom;
+
+    feeAdapter.batchApplyFees(keys);
+
+    assertEq(poolManager.getProtocolFee(pool3000.toId()), _packFee(TIER_FEE_3000));
+    assertEq(poolManager.getProtocolFee(pool500.toId()), _packFee(POOL_OVERRIDE_FEE));
+    assertEq(poolManager.getProtocolFee(poolCustom.toId()), _packFee(DEFAULT_FEE));
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    CLEAR OVERRIDE TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_clearPoolOverride_fallsBackToTier() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+
+    // Verify pool override is active
+    assertEq(feeAdapter.getFee(pool3000), _packFee(POOL_OVERRIDE_FEE));
+
+    // Clear pool override
+    feeAdapter.clearPoolOverride(pool3000.toId());
+    vm.stopPrank();
+
+    // Should now fall back to tier override
+    assertEq(feeAdapter.getFee(pool3000), _packFee(TIER_FEE_3000));
+  }
+
+  function test_clearFeeTierOverride_fallsBackToDefault() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+
+    // Verify tier override is active
+    assertEq(feeAdapter.getFee(pool3000), _packFee(TIER_FEE_3000));
+
+    // Clear tier override
+    feeAdapter.clearFeeTierOverride(3000);
+    vm.stopPrank();
+
+    // Should now fall back to default
+    assertEq(feeAdapter.getFee(pool3000), _packFee(DEFAULT_FEE));
+  }
+
+  function test_clearOverride_emitsEvent() public {
+    vm.startPrank(owner);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+
+    vm.expectEmit(true, false, false, true);
+    emit IV4FeeAdapter.PoolOverrideUpdated(pool3000.toId(), 0); // 0 = cleared
+    feeAdapter.clearPoolOverride(pool3000.toId());
+    vm.stopPrank();
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    ACCESS CONTROL TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_setDefaultFee_onlyFeeSetter() public {
+    vm.prank(alice);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+  }
+
+  function test_setFeeTierOverride_onlyFeeSetter() public {
+    vm.prank(alice);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+  }
+
+  function test_setPoolOverride_onlyFeeSetter() public {
+    vm.prank(alice);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+  }
+
+  function test_clearFeeTierOverride_onlyFeeSetter() public {
+    vm.prank(alice);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.clearFeeTierOverride(3000);
+  }
+
+  function test_clearPoolOverride_onlyFeeSetter() public {
+    vm.prank(alice);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.clearPoolOverride(pool3000.toId());
+  }
+
+  function test_setFeeSetter_onlyOwner() public {
+    vm.prank(alice);
+    vm.expectRevert("UNAUTHORIZED");
+    feeAdapter.setFeeSetter(alice);
+  }
+
+  function test_setFeeSetter_success() public {
+    vm.prank(owner);
+    feeAdapter.setFeeSetter(alice);
+
+    assertEq(feeAdapter.feeSetter(), alice);
+
+    // Alice can now set fees
+    vm.prank(alice);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+    assertEq(feeAdapter.defaultFee(), DEFAULT_FEE);
+  }
+
+  function test_collectProtocolFees_onlyOwner() public {
+    vm.prank(alice);
+    vm.expectRevert("UNAUTHORIZED");
+    feeAdapter.collectProtocolFees(Currency.wrap(address(mockToken)), 0);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    FEE VALIDATION TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_setDefaultFee_revertsWithInvalidFee() public {
+    uint24 invalidFee = 2000; // > MAX_PROTOCOL_FEE (1000)
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, invalidFee));
+    feeAdapter.setDefaultFee(invalidFee);
+  }
+
+  function test_setFeeTierOverride_revertsWithInvalidFee() public {
+    uint24 invalidFee = 1001; // Just over max
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, invalidFee));
+    feeAdapter.setFeeTierOverride(3000, invalidFee);
+  }
+
+  function test_setPoolOverride_revertsWithInvalidFee() public {
+    uint24 invalidFee = 1001; // Just over max (single direction)
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, invalidFee));
+    feeAdapter.setPoolOverride(pool3000.toId(), invalidFee);
+  }
+
+  function test_setFee_acceptsMaxValidFee() public {
+    vm.prank(owner);
+    feeAdapter.setDefaultFee(MAX_VALID_FEE); // 1000 pips (0.1%)
+    assertEq(feeAdapter.defaultFee(), MAX_VALID_FEE);
+    assertEq(feeAdapter.getFee(pool3000), _packFee(MAX_VALID_FEE));
+  }
+
+  function test_setFee_acceptsZeroFee() public {
+    vm.prank(owner);
+    feeAdapter.setDefaultFee(0);
+    // Storage is encoded: 0 becomes ZERO_FEE_SENTINEL
+    assertEq(feeAdapter.defaultFee(), feeAdapter.ZERO_FEE_SENTINEL());
+    // But getFee should decode it back to 0
+    assertEq(feeAdapter.getFee(pool3000), 0);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                       EVENT TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_setDefaultFee_emitsEvent() public {
+    vm.prank(owner);
+    vm.expectEmit(false, false, false, true);
+    emit IV4FeeAdapter.DefaultFeeUpdated(DEFAULT_FEE);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+  }
+
+  function test_setFeeTierOverride_emitsEvent() public {
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, true);
+    emit IV4FeeAdapter.FeeTierOverrideUpdated(3000, TIER_FEE_3000);
+    feeAdapter.setFeeTierOverride(3000, TIER_FEE_3000);
+  }
+
+  function test_setPoolOverride_emitsEvent() public {
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, true);
+    emit IV4FeeAdapter.PoolOverrideUpdated(pool3000.toId(), POOL_OVERRIDE_FEE);
+    feeAdapter.setPoolOverride(pool3000.toId(), POOL_OVERRIDE_FEE);
+  }
+
+  function test_setFeeSetter_emitsEvent() public {
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, false);
+    emit IV4FeeAdapter.FeeSetterUpdated(alice);
+    feeAdapter.setFeeSetter(alice);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    FEE COLLECTION TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_collectProtocolFees_success() public {
+    // Setup: accrue some fees in the pool manager
+    uint256 accruedAmount = 100e18;
+    poolManager.setProtocolFeesAccrued(Currency.wrap(address(mockToken)), accruedAmount);
+
+    // Fund the pool manager so it can transfer
+    mockToken.mint(address(poolManager), accruedAmount);
+
+    uint256 tokenJarBalanceBefore = mockToken.balanceOf(address(tokenJar));
+
+    vm.prank(owner);
+    uint256 collected = feeAdapter.collectProtocolFees(Currency.wrap(address(mockToken)), accruedAmount);
+
+    assertEq(collected, accruedAmount);
+    assertEq(mockToken.balanceOf(address(tokenJar)), tokenJarBalanceBefore + accruedAmount);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                        FUZZ TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function testFuzz_setDefaultFee(uint24 fee) public {
+    vm.startPrank(owner);
+
+    // 0 is valid (explicitly disabled), otherwise must be <= MAX_PROTOCOL_FEE (1000)
+    if (fee != 0 && fee > ProtocolFeeLibrary.MAX_PROTOCOL_FEE) {
+      vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, fee));
+      feeAdapter.setDefaultFee(fee);
+    } else {
+      feeAdapter.setDefaultFee(fee);
+      // Storage is encoded: 0 becomes ZERO_FEE_SENTINEL
+      uint24 expectedStored = fee == 0 ? feeAdapter.ZERO_FEE_SENTINEL() : fee;
+      assertEq(feeAdapter.defaultFee(), expectedStored);
+    }
+
+    vm.stopPrank();
+  }
+
+  function testFuzz_setFeeTierOverride(uint24 lpFee, uint24 protocolFee) public {
+    vm.startPrank(owner);
+
+    if (protocolFee != 0 && protocolFee > ProtocolFeeLibrary.MAX_PROTOCOL_FEE) {
+      vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, protocolFee));
+      feeAdapter.setFeeTierOverride(lpFee, protocolFee);
+    } else {
+      feeAdapter.setFeeTierOverride(lpFee, protocolFee);
+      // Storage is encoded: 0 becomes ZERO_FEE_SENTINEL
+      uint24 expectedStored = protocolFee == 0 ? feeAdapter.ZERO_FEE_SENTINEL() : protocolFee;
+      assertEq(feeAdapter.feeTierOverrides(lpFee), expectedStored);
+    }
+
+    vm.stopPrank();
+  }
+
+  function testFuzz_setPoolOverride(bytes32 poolIdRaw, uint24 protocolFee) public {
+    PoolId poolId = PoolId.wrap(poolIdRaw);
+
+    vm.startPrank(owner);
+
+    if (protocolFee != 0 && protocolFee > ProtocolFeeLibrary.MAX_PROTOCOL_FEE) {
+      vm.expectRevert(abi.encodeWithSelector(IV4FeeAdapter.ProtocolFeeTooLarge.selector, protocolFee));
+      feeAdapter.setPoolOverride(poolId, protocolFee);
+    } else {
+      feeAdapter.setPoolOverride(poolId, protocolFee);
+      // Storage is encoded: 0 becomes ZERO_FEE_SENTINEL
+      uint24 expectedStored = protocolFee == 0 ? feeAdapter.ZERO_FEE_SENTINEL() : protocolFee;
+      assertEq(feeAdapter.poolOverrides(poolId), expectedStored);
+    }
+
+    vm.stopPrank();
+  }
+
+  function testFuzz_setFeeSetter(address newFeeSetter) public {
+    vm.prank(owner);
+    feeAdapter.setFeeSetter(newFeeSetter);
+    assertEq(feeAdapter.feeSetter(), newFeeSetter);
+  }
+
+  function testFuzz_onlyFeeSetterCanSetFees(address caller) public {
+    vm.assume(caller != owner); // owner is the feeSetter
+
+    vm.prank(caller);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    feeAdapter.setDefaultFee(DEFAULT_FEE);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    WATERFALL PRIORITY TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_waterfall_poolOverrideHasHighestPriority() public {
+    vm.startPrank(owner);
+    // Set all three levels to different values
+    feeAdapter.setDefaultFee(100);
+    feeAdapter.setFeeTierOverride(3000, 200);
+    feeAdapter.setPoolOverride(pool3000.toId(), 300);
+    vm.stopPrank();
+
+    // Pool override should win
+    assertEq(feeAdapter.getFee(pool3000), _packFee(300));
+  }
+
+  function test_waterfall_feeTierHasSecondPriority() public {
+    vm.startPrank(owner);
+    // Set default and tier (no pool override)
+    feeAdapter.setDefaultFee(100);
+    feeAdapter.setFeeTierOverride(3000, 200);
+    vm.stopPrank();
+
+    // Fee tier should win over default
+    assertEq(feeAdapter.getFee(pool3000), _packFee(200));
+  }
+
+  function test_waterfall_defaultIsLastResort() public {
+    vm.startPrank(owner);
+    // Only set default
+    feeAdapter.setDefaultFee(100);
+    vm.stopPrank();
+
+    // Default should be used
+    assertEq(feeAdapter.getFee(pool3000), _packFee(100));
+  }
+
+  function test_waterfall_zeroIsValidOverride() public {
+    vm.startPrank(owner);
+    feeAdapter.setDefaultFee(500);
+    feeAdapter.setFeeTierOverride(3000, 300);
+    // Set pool override to 0 (explicitly disable fees for this pool)
+    feeAdapter.setPoolOverride(pool3000.toId(), 0);
+    vm.stopPrank();
+
+    // Zero should be returned (not fall through to tier/default, no packing for zero)
+    assertEq(feeAdapter.getFee(pool3000), 0);
+  }
+}

--- a/test/V4ProtocolFees.fork.t.sol
+++ b/test/V4ProtocolFees.fork.t.sol
@@ -1,0 +1,1129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/types/PoolId.sol";
+import {Currency, CurrencyLibrary} from "v4-core/types/Currency.sol";
+import {IHooks} from "v4-core/interfaces/IHooks.sol";
+import {StateLibrary} from "v4-core/libraries/StateLibrary.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "v4-core/types/BalanceDelta.sol";
+import {SwapParams} from "v4-core/types/PoolOperation.sol";
+import {IUnlockCallback} from "v4-core/interfaces/callback/IUnlockCallback.sol";
+import {TickMath} from "v4-core/libraries/TickMath.sol";
+import {ProtocolFeeLibrary} from "v4-core/libraries/ProtocolFeeLibrary.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {V4FeeAdapter} from "../src/feeAdapters/V4FeeAdapter.sol";
+import {IV4FeeAdapter} from "../src/interfaces/IV4FeeAdapter.sol";
+import {IOwned} from "../src/interfaces/base/IOwned.sol";
+import {V4FeeSwitchProposal} from "../script/05_V4FeeSwitchProposal.s.sol";
+import {MainnetDeployer} from "../script/deployers/MainnetDeployer.sol";
+import {UnificationProposal} from "../script/04_UnificationProposal.s.sol";
+
+/// @notice Minimal swap helper that implements the unlock callback pattern
+contract SwapHelper is IUnlockCallback {
+  using CurrencyLibrary for Currency;
+
+  IPoolManager public immutable poolManager;
+
+  struct SwapCallbackData {
+    PoolKey key;
+    SwapParams params;
+    address sender;
+  }
+
+  constructor(IPoolManager _poolManager) {
+    poolManager = _poolManager;
+  }
+
+  /// @notice Execute a swap via the unlock pattern
+  function swap(PoolKey memory key, SwapParams memory params) external payable returns (BalanceDelta delta) {
+    bytes memory result = poolManager.unlock(abi.encode(SwapCallbackData(key, params, msg.sender)));
+    delta = abi.decode(result, (BalanceDelta));
+  }
+
+  /// @notice Callback from PoolManager.unlock()
+  function unlockCallback(bytes calldata data) external override returns (bytes memory) {
+    require(msg.sender == address(poolManager), "Only PoolManager");
+
+    SwapCallbackData memory swapData = abi.decode(data, (SwapCallbackData));
+
+    // Execute the swap
+    BalanceDelta delta = poolManager.swap(swapData.key, swapData.params, "");
+
+    // Settle the swap - handle what we owe and what we're owed
+    // delta.amount0() < 0 means we owe token0, > 0 means we're owed token0
+    int128 amount0 = delta.amount0();
+    int128 amount1 = delta.amount1();
+
+    // Settle negative deltas (what we owe)
+    if (amount0 < 0) {
+      _settle(swapData.key.currency0, swapData.sender, uint128(-amount0));
+    }
+    if (amount1 < 0) {
+      _settle(swapData.key.currency1, swapData.sender, uint128(-amount1));
+    }
+
+    // Take positive deltas (what we're owed)
+    if (amount0 > 0) {
+      poolManager.take(swapData.key.currency0, swapData.sender, uint128(amount0));
+    }
+    if (amount1 > 0) {
+      poolManager.take(swapData.key.currency1, swapData.sender, uint128(amount1));
+    }
+
+    return abi.encode(delta);
+  }
+
+  function _settle(Currency currency, address payer, uint256 amount) internal {
+    if (currency.isAddressZero()) {
+      // Native ETH - settle with value
+      poolManager.settle{value: amount}();
+    } else {
+      // ERC20 - transfer then sync then settle
+      poolManager.sync(currency);
+      IERC20(Currency.unwrap(currency)).transferFrom(payer, address(poolManager), amount);
+      poolManager.settle();
+    }
+  }
+
+  receive() external payable {}
+}
+
+/// @title V4ProtocolFeesForkTest
+/// @notice Fork tests for the V4 fee switch proposal
+contract V4ProtocolFeesForkTest is Test {
+  using PoolIdLibrary for PoolKey;
+  using StateLibrary for IPoolManager;
+
+  // Mainnet addresses
+  IPoolManager public constant POOL_MANAGER = IPoolManager(0x000000000004444c5dc75cB358380D2e3dE08A90);
+  address constant ETH = address(0);
+  address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+  address constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+  address constant cbBTC = 0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf;
+  address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+  address constant USDE = 0x4c9EDD5852cd905f086C759E8383e09bff1E68B3;
+
+  // Real V4 pool IDs (for verification)
+  bytes32 constant ETH_USDC_POOL_ID = 0xdce6394339af00981949f5f3baf27e3610c76326a700af57e4b3e3ae4977f78d;
+  bytes32 constant WBTC_CBBTC_POOL_ID = 0x2f92b371aef58f0abe9c10c06423de083405991f2839638914a1031e91d9a723;
+  bytes32 constant USDC_USDT_POOL_ID_10 = 0x8aa4e11cbdf30eedc92100f4c8a31ff748e201d44712cc8c90d189edaa8e4e47; // 0.001% fee
+  bytes32 constant USDE_USDT_POOL_ID = 0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7; // 0.0045% fee
+  bytes32 constant USDC_USDT_POOL_ID_8 = 0x395f91b34aa34a477ce3bc6505639a821b286a62b1a164fc1887fa3a5ef713a5; // 0.0008% fee
+
+  // Deployed contracts
+  V4FeeAdapter public v4FeeAdapter;
+  MainnetDeployer public deployer;
+  SwapHelper public swapHelper;
+
+  // Test addresses
+  address public poolManagerOwner;
+  address public tokenJar;
+
+  // Test pool keys
+  PoolKey[] internal testPools;
+
+  // Fork from a recent block where V4 is deployed
+  // V4 was deployed on mainnet in January 2025
+  uint256 constant FORK_BLOCK = 24_106_377;
+
+  /// @notice Packs a single-direction fee into the V4 format (symmetric for both directions)
+  /// @dev V4 protocol fee is a uint24: lower 12 bits = zeroForOne, upper 12 bits = oneForZero
+  function _packFee(uint24 fee) internal pure returns (uint24) {
+    return (fee << 12) | fee;
+  }
+
+  function setUp() public {
+    vm.createSelectFork("mainnet", FORK_BLOCK);
+
+    // Get the PoolManager owner (this is who can set the protocol fee controller)
+    poolManagerOwner = IOwned(address(POOL_MANAGER)).owner();
+
+    // Deploy the unification proposal infrastructure first to get TokenJar
+    deployer = new MainnetDeployer();
+    UnificationProposal unificationProposal = new UnificationProposal();
+    unificationProposal.runPranked(deployer);
+    tokenJar = address(deployer.TOKEN_JAR());
+
+    // Deploy the V4FeeAdapter
+    // The owner should be the PoolManager owner (governance timelock)
+    // The feeSetter is also the owner initially
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter = new V4FeeAdapter(
+      address(POOL_MANAGER),
+      tokenJar,
+      poolManagerOwner, // feeSetter
+      0 // No default fee initially
+    );
+
+    // Deploy the swap helper for swap tests
+    swapHelper = new SwapHelper(POOL_MANAGER);
+
+    // Setup test pool keys for common fee tiers
+    // These are synthetic pools for testing - in production we'd use real pool addresses
+    _setupTestPoolKeys();
+  }
+
+  function _setupTestPoolKeys() internal {
+    // Create pool keys for REAL initialized V4 pools on mainnet
+
+    // ETH/USDC 0.30% pool (3000 bps LP fee, tickSpacing 60)
+    // Pool ID: 0xdce6394339af00981949f5f3baf27e3610c76326a700af57e4b3e3ae4977f78d
+    PoolKey memory ethUsdc = PoolKey({
+      currency0: Currency.wrap(ETH), // ETH = address(0)
+      currency1: Currency.wrap(USDC),
+      fee: 3000,
+      tickSpacing: 60,
+      hooks: IHooks(address(0))
+    });
+    // Verify the pool ID matches
+    require(PoolId.unwrap(ethUsdc.toId()) == ETH_USDC_POOL_ID, "ETH/USDC pool ID mismatch");
+    testPools.push(ethUsdc);
+
+    // WBTC/cbBTC 0.01% pool (100 bps LP fee, tickSpacing 1)
+    // Pool ID: 0x2f92b371aef58f0abe9c10c06423de083405991f2839638914a1031e91d9a723
+    PoolKey memory wbtcCbbtc = PoolKey({
+      currency0: Currency.wrap(WBTC), // WBTC < cbBTC by address
+      currency1: Currency.wrap(cbBTC),
+      fee: 100,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    // Verify the pool ID matches
+    require(PoolId.unwrap(wbtcCbbtc.toId()) == WBTC_CBBTC_POOL_ID, "WBTC/cbBTC pool ID mismatch");
+    testPools.push(wbtcCbbtc);
+
+    // USDC/USDT 0.001% pool (10 bps LP fee, tickSpacing 1)
+    // Pool ID: 0x8aa4e11cbdf30eedc92100f4c8a31ff748e201d44712cc8c90d189edaa8e4e47
+    PoolKey memory usdcUsdt10 = PoolKey({
+      currency0: Currency.wrap(USDC), // USDC < USDT by address
+      currency1: Currency.wrap(USDT),
+      fee: 10,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    // Verify the pool ID matches
+    require(PoolId.unwrap(usdcUsdt10.toId()) == USDC_USDT_POOL_ID_10, "USDC/USDT 10 pool ID mismatch");
+    testPools.push(usdcUsdt10);
+
+    // USDE/USDT 0.0045% pool (45 bps LP fee, tickSpacing 1)
+    // Pool ID: 0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7
+    PoolKey memory usdeUsdt = PoolKey({
+      currency0: Currency.wrap(USDE), // USDE < USDT by address
+      currency1: Currency.wrap(USDT),
+      fee: 45,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    // Verify the pool ID matches
+    require(PoolId.unwrap(usdeUsdt.toId()) == USDE_USDT_POOL_ID, "USDE/USDT pool ID mismatch");
+    testPools.push(usdeUsdt);
+
+    // USDC/USDT 0.0008% pool (8 bps LP fee, tickSpacing 1)
+    // Pool ID: 0x395f91b34aa34a477ce3bc6505639a821b286a62b1a164fc1887fa3a5ef713a5
+    PoolKey memory usdcUsdt8 = PoolKey({
+      currency0: Currency.wrap(USDC), // USDC < USDT by address
+      currency1: Currency.wrap(USDT),
+      fee: 8,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    // Verify the pool ID matches
+    require(PoolId.unwrap(usdcUsdt8.toId()) == USDC_USDT_POOL_ID_8, "USDC/USDT 8 pool ID mismatch");
+    testPools.push(usdcUsdt8);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    PROPOSAL EXECUTION TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_proposalExecution_setsProtocolFeeController() public {
+    // Execute the proposal
+    _executeV4Proposal();
+
+    // Verify the protocol fee controller is set
+    assertEq(POOL_MANAGER.protocolFeeController(), address(v4FeeAdapter));
+  }
+
+  function test_proposalExecution_setsDefaultFee() public {
+    _executeV4Proposal();
+
+    // Default fee should be set to 750 (DEFAULT_PROTOCOL_FEE from the proposal)
+    uint24 expectedDefault = 750;
+
+    // For a pool with no tier override, it should return the default
+    PoolKey memory unknownTierPool = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 9999, // Unusual fee tier with no override
+      tickSpacing: 100,
+      hooks: IHooks(address(0))
+    });
+
+    assertEq(v4FeeAdapter.getFee(unknownTierPool), _packFee(expectedDefault));
+  }
+
+  function test_proposalExecution_setsTierOverrides() public {
+    _executeV4Proposal();
+
+    // Helper to create a pool key for a given fee tier
+    // Note: tickSpacing doesn't affect fee resolution, just needs to be valid
+
+    // 8 bps LP fee tier (0.0008%) / 4 = 2 pips (TIER_8_FEE)
+    PoolKey memory pool8 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 8,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool8), _packFee(2), "TIER_8_FEE");
+
+    // 10 bps LP fee tier (0.001%) / 4 = 3 pips (TIER_10_FEE)
+    PoolKey memory pool10 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 10,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool10), _packFee(3), "TIER_10_FEE");
+
+    // 45 bps LP fee tier (0.0045%) / 4 = 11 pips (TIER_45_FEE)
+    PoolKey memory pool45 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 45,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool45), _packFee(11), "TIER_45_FEE");
+
+    // 100 bps LP fee tier (0.01%) / 4 = 25 pips (TIER_100_FEE)
+    PoolKey memory pool100 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 100,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool100), _packFee(25), "TIER_100_FEE");
+
+    // 500 bps LP fee tier (0.05%) / 4 = 125 pips (TIER_500_FEE)
+    PoolKey memory pool500 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 500,
+      tickSpacing: 10,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool500), _packFee(125), "TIER_500_FEE");
+
+    // 3000 bps LP fee tier (0.30%) / 6 = 500 pips (TIER_3000_FEE)
+    PoolKey memory pool3000 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 3000,
+      tickSpacing: 60,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool3000), _packFee(500), "TIER_3000_FEE");
+
+    // 10000 bps LP fee tier (1.00%) / 6 = 1000 pips capped (TIER_10000_FEE)
+    PoolKey memory pool10000 = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 10000,
+      tickSpacing: 200,
+      hooks: IHooks(address(0))
+    });
+    assertEq(v4FeeAdapter.getFee(pool10000), _packFee(1000), "TIER_10000_FEE");
+  }
+
+  function test_proposalExecution_appliesFeesToPools() public {
+    _executeV4Proposal();
+
+    // After proposal execution, fees should be applied to the test pools
+    // The protocol fee should be set on the PoolManager for each pool
+    for (uint256 i = 0; i < testPools.length; i++) {
+      PoolKey memory key = testPools[i];
+      PoolId poolId = key.toId();
+
+      // Get the expected fee from our adapter
+      uint24 expectedFee = v4FeeAdapter.getFee(key);
+
+      // Get the actual protocol fee from the pool state
+      // Note: This only works if the pool is initialized
+      // For uninitialized pools, we just verify the adapter returns the right fee
+      (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, poolId);
+
+      // If the pool exists and was in our batch, the fee should match
+      // If not, this is still a valid test of the adapter's resolution logic
+      if (protocolFee != 0) {
+        assertEq(protocolFee, expectedFee, "Protocol fee mismatch for pool");
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      FEE RESOLUTION TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @notice Verify each real pool resolves to the correct tier-based fee
+  function test_feeResolution_eachPoolGetsCorrectTierFee() public {
+    _executeV4Proposal();
+
+    // ETH/USDC: 3000 tier → TIER_3000_FEE (500)
+    assertEq(v4FeeAdapter.getFee(testPools[0]), _packFee(500), "ETH/USDC should get TIER_3000_FEE");
+
+    // WBTC/cbBTC: 100 tier → TIER_100_FEE (25)
+    assertEq(v4FeeAdapter.getFee(testPools[1]), _packFee(25), "WBTC/cbBTC should get TIER_100_FEE");
+
+    // USDC/USDT (10): 10 tier → TIER_10_FEE (3)
+    assertEq(v4FeeAdapter.getFee(testPools[2]), _packFee(3), "USDC/USDT 10 should get TIER_10_FEE");
+
+    // USDE/USDT: 45 tier → TIER_45_FEE (11)
+    assertEq(v4FeeAdapter.getFee(testPools[3]), _packFee(11), "USDE/USDT should get TIER_45_FEE");
+
+    // USDC/USDT (8): 8 tier → TIER_8_FEE (2)
+    assertEq(v4FeeAdapter.getFee(testPools[4]), _packFee(2), "USDC/USDT 8 should get TIER_8_FEE");
+  }
+
+  /// @notice Test that pools with unregistered tiers fall back to default
+  function test_feeResolution_unregisteredTierFallsBackToDefault() public {
+    _executeV4Proposal();
+
+    // Create a pool with a tier that has no override (e.g., 77)
+    PoolKey memory unknownTierPool = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 77, // No tier override for this
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+
+    // Should fall back to default (750)
+    assertEq(v4FeeAdapter.getFee(unknownTierPool), _packFee(750), "Unknown tier should fall back to default");
+  }
+
+  /// @notice Test the full waterfall with NO overrides set (only default)
+  function test_feeResolution_noOverridesOnlyDefault() public {
+    // Deploy fresh adapter with just a default fee, no tier overrides
+    vm.prank(poolManagerOwner);
+    V4FeeAdapter freshAdapter = new V4FeeAdapter(
+      address(POOL_MANAGER),
+      tokenJar,
+      poolManagerOwner,
+      0 // Start with no default
+    );
+
+    // Set ONLY the default fee
+    vm.prank(poolManagerOwner);
+    freshAdapter.setDefaultFee(250);
+
+    // All pools should get the default fee regardless of their tier
+    for (uint256 i = 0; i < testPools.length; i++) {
+      assertEq(freshAdapter.getFee(testPools[i]), _packFee(250), "All pools should get default when no tier overrides");
+    }
+  }
+
+  /// @notice Test that clearing a tier override falls back to default
+  function test_feeResolution_clearTierOverrideFallsBackToDefault() public {
+    _executeV4Proposal();
+
+    // ETH/USDC uses 3000 tier → currently 500 (TIER_3000_FEE)
+    PoolKey memory pool = testPools[0];
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(500), "Should start with tier fee");
+
+    // Clear the 3000 tier override
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.clearFeeTierOverride(3000);
+
+    // Should now fall back to default (750)
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(750), "Should fall back to default after clearing tier");
+
+    // To prove it's using default and not tier, change the default
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setDefaultFee(999);
+
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(999), "Should now use new default after tier cleared");
+  }
+
+  /// @notice Test setting tier override to zero explicitly disables fees for that tier
+  function test_feeResolution_zeroTierOverrideDisablesFees() public {
+    _executeV4Proposal();
+
+    // WBTC/cbBTC uses 100 tier → currently 25 (TIER_100_FEE)
+    PoolKey memory pool = testPools[1];
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(25), "Should start with tier fee");
+
+    // Set tier 100 to explicitly zero
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setFeeTierOverride(100, 0);
+
+    // Fee should now be 0 (NOT falling back to default)
+    assertEq(v4FeeAdapter.getFee(pool), 0, "Zero tier override should disable fees");
+  }
+
+  /// @notice Test pool override takes precedence over tier override
+  function test_feeResolution_poolOverrideTakesPrecedence() public {
+    _executeV4Proposal();
+
+    // Test on each pool to ensure pool override works for all tiers
+    for (uint256 i = 0; i < testPools.length; i++) {
+      PoolKey memory pool = testPools[i];
+      uint24 tierFee = v4FeeAdapter.getFee(pool);
+
+      // Set a pool-specific override different from tier
+      uint24 poolOverrideFee = 333;
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.setPoolOverride(pool.toId(), poolOverrideFee);
+
+      // Pool override should take precedence over tier
+      assertEq(v4FeeAdapter.getFee(pool), _packFee(poolOverrideFee), "Pool override should take precedence");
+
+      // Clean up for next iteration
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.clearPoolOverride(pool.toId());
+      assertEq(v4FeeAdapter.getFee(pool), tierFee, "Should restore to tier fee");
+    }
+  }
+
+  /// @notice Test setting pool override to zero disables fees (doesn't fall through)
+  function test_feeResolution_zeroPoolOverrideDisablesFees() public {
+    _executeV4Proposal();
+
+    // Test on multiple pools with different tiers
+    for (uint256 i = 0; i < testPools.length; i++) {
+      PoolKey memory pool = testPools[i];
+      uint24 tierFee = v4FeeAdapter.getFee(pool);
+      assertTrue(tierFee > 0, "Pool should have non-zero tier fee");
+
+      // Set pool override to 0 (disable fees)
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.setPoolOverride(pool.toId(), 0);
+
+      // Fee should now be 0 (NOT falling back to tier)
+      assertEq(v4FeeAdapter.getFee(pool), 0, "Zero pool override should disable fees");
+
+      // Clean up
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.clearPoolOverride(pool.toId());
+    }
+  }
+
+  /// @notice Test clearing pool override falls back to tier
+  function test_feeResolution_clearPoolOverrideFallsBackToTier() public {
+    _executeV4Proposal();
+
+    // Test on each pool
+    for (uint256 i = 0; i < testPools.length; i++) {
+      PoolKey memory pool = testPools[i];
+      uint24 expectedTierFee = v4FeeAdapter.getFee(pool);
+
+      // Set a pool override
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.setPoolOverride(pool.toId(), 999);
+      assertEq(v4FeeAdapter.getFee(pool), _packFee(999), "Pool override should be set");
+
+      // Clear the pool override
+      vm.prank(poolManagerOwner);
+      v4FeeAdapter.clearPoolOverride(pool.toId());
+
+      // Should fall back to tier fee
+      assertEq(v4FeeAdapter.getFee(pool), expectedTierFee, "Should fall back to tier fee");
+    }
+  }
+
+  /// @notice Test full waterfall: pool override → tier override → default
+  function test_feeResolution_fullWaterfallChain() public {
+    _executeV4Proposal();
+
+    // Use ETH/USDC (3000 tier, 500 fee)
+    PoolKey memory pool = testPools[0];
+
+    // 1. Start: tier override active → 500
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(500), "Step 1: Should use tier override");
+
+    // 2. Set pool override → 111
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(pool.toId(), 111);
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(111), "Step 2: Pool override takes precedence");
+
+    // 3. Clear pool override → back to tier (500)
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.clearPoolOverride(pool.toId());
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(500), "Step 3: Falls back to tier");
+
+    // 4. Clear tier override → falls to default (750)
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.clearFeeTierOverride(3000);
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(750), "Step 4: Falls back to default");
+
+    // 5. Change default → reflects new default
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setDefaultFee(777);
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(777), "Step 5: Uses new default");
+
+    // 6. Re-add tier override → uses tier again
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setFeeTierOverride(3000, 444);
+    assertEq(v4FeeAdapter.getFee(pool), _packFee(444), "Step 6: Tier override active again");
+
+    // 7. Set pool override to 0 → disables fees (doesn't fall through)
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(pool.toId(), 0);
+    assertEq(v4FeeAdapter.getFee(pool), 0, "Step 7: Zero pool override disables fees");
+  }
+
+  /// @notice Test that zero default works correctly
+  function test_feeResolution_zeroDefaultFee() public {
+    // Deploy fresh adapter with zero default
+    vm.prank(poolManagerOwner);
+    V4FeeAdapter freshAdapter = new V4FeeAdapter(
+      address(POOL_MANAGER),
+      tokenJar,
+      poolManagerOwner,
+      0 // Zero default
+    );
+
+    // Pool with no tier override should get 0
+    PoolKey memory unknownTierPool = PoolKey({
+      currency0: Currency.wrap(address(1)),
+      currency1: Currency.wrap(address(2)),
+      fee: 77,
+      tickSpacing: 1,
+      hooks: IHooks(address(0))
+    });
+
+    assertEq(freshAdapter.getFee(unknownTierPool), 0, "Should return 0 with zero default");
+
+    // Add a tier override, pool with that tier should get the override
+    vm.prank(poolManagerOwner);
+    freshAdapter.setFeeTierOverride(77, 123);
+    assertEq(freshAdapter.getFee(unknownTierPool), _packFee(123), "Should use tier override");
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      ACCESS CONTROL TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_accessControl_onlyFeeSetterCanSetFees() public {
+    _executeV4Proposal();
+
+    address notFeeSetter = makeAddr("notFeeSetter");
+
+    vm.prank(notFeeSetter);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    v4FeeAdapter.setDefaultFee(100);
+
+    vm.prank(notFeeSetter);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    v4FeeAdapter.setFeeTierOverride(500, 100);
+
+    vm.prank(notFeeSetter);
+    vm.expectRevert(IV4FeeAdapter.Unauthorized.selector);
+    v4FeeAdapter.setPoolOverride(testPools[0].toId(), 100);
+  }
+
+  function test_accessControl_ownerCanTransferFeeSetter() public {
+    _executeV4Proposal();
+
+    address newFeeSetter = makeAddr("newFeeSetter");
+
+    // Transfer feeSetter role
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setFeeSetter(newFeeSetter);
+
+    assertEq(v4FeeAdapter.feeSetter(), newFeeSetter);
+
+    // New fee setter can set fees
+    vm.prank(newFeeSetter);
+    v4FeeAdapter.setDefaultFee(100);
+    // Should not revert
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      APPLY FEE TESTS
+  // ═══════════════════════════════════════════════════════════════
+
+  function test_applyFee_updatesPoolManagerProtocolFee() public {
+    _executeV4Proposal();
+
+    // Pick a pool and change its override
+    PoolKey memory pool = testPools[0];
+    uint24 newFee = 300;
+
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(pool.toId(), newFee);
+
+    // Apply the new fee
+    v4FeeAdapter.applyFee(pool);
+
+    // Verify the PoolManager has the new fee
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, pool.toId());
+    assertEq(protocolFee, _packFee(newFee));
+  }
+
+  function test_batchApplyFees_updatesMultiplePools() public {
+    _executeV4Proposal();
+
+    // Set different overrides for each pool
+    vm.startPrank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(testPools[0].toId(), 100);
+    v4FeeAdapter.setPoolOverride(testPools[1].toId(), 200);
+    vm.stopPrank();
+
+    // Batch apply
+    v4FeeAdapter.batchApplyFees(testPools);
+
+    // Verify each pool
+    (,, uint24 fee0,) = StateLibrary.getSlot0(POOL_MANAGER, testPools[0].toId());
+    (,, uint24 fee1,) = StateLibrary.getSlot0(POOL_MANAGER, testPools[1].toId());
+    assertEq(fee0, _packFee(100));
+    assertEq(fee1, _packFee(200));
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                      SWAP TESTS (E2E)
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @notice Verify ETH/USDC (3000 tier) collects exactly 500 pips (0.05%) protocol fee
+  function test_swap_ETH_USDC_collects500Pips() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC, 3000 tier
+    uint24 expectedFeePips = 500; // TIER_3000_FEE
+
+    // Verify the fee is set correctly
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, pool.toId());
+    assertEq(protocolFee, _packFee(expectedFeePips), "Protocol fee should be 500 pips");
+
+    // Perform swap and validate fee
+    uint256 swapAmount = 1 ether;
+    uint256 collectedFee = _swapAndGetFee(pool, swapAmount);
+
+    // Expected: 1 ETH * 500 / 1_000_000 = 0.0005 ETH = 500000000000000 wei
+    uint256 expectedFee = (swapAmount * expectedFeePips) / 1_000_000;
+    assertEq(expectedFee, 500000000000000, "Sanity check: expected fee calculation");
+
+    // Exact match - no tolerance
+    assertEq(collectedFee, expectedFee, "Fee must be exactly 500 pips of input");
+  }
+
+  /// @notice Verify each tier collects the correct protocol fee rate
+  function test_swap_allTiersCollectCorrectFees() public {
+    _executeV4Proposal();
+
+    // Test pool 0: ETH/USDC (3000 tier) → 500 pips
+    _verifyPoolFeeRate(testPools[0], 500, "ETH/USDC 3000 tier");
+
+    // Test pool 2: USDC/USDT (10 tier) → 3 pips
+    _verifyPoolFeeRate(testPools[2], 3, "USDC/USDT 10 tier");
+
+    // Test pool 3: USDE/USDT (45 tier) → 11 pips
+    _verifyPoolFeeRate(testPools[3], 11, "USDE/USDT 45 tier");
+
+    // Test pool 4: USDC/USDT (8 tier) → 2 pips
+    _verifyPoolFeeRate(testPools[4], 2, "USDC/USDT 8 tier");
+  }
+
+  /// @notice Verify fee changes take effect immediately on next swap
+  function test_swap_feeChangeAffectsNextSwap() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC
+    PoolId poolId = pool.toId();
+    uint256 swapAmount = 1 ether;
+
+    // === Swap 1: Default tier fee (500 pips) ===
+    uint256 fee1 = _swapAndGetFee(pool, swapAmount);
+    uint256 expected1 = (swapAmount * 500) / 1_000_000;
+    assertEq(fee1, expected1, "Swap 1: must collect exactly 500 pips");
+
+    // === Change to custom pool override (800 pips) ===
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, 800);
+    v4FeeAdapter.applyFee(pool);
+
+    // Verify fee changed
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, poolId);
+    assertEq(protocolFee, _packFee(800), "Fee should be 800 pips");
+
+    // === Swap 2: Custom fee (800 pips) ===
+    uint256 fee2 = _swapAndGetFee(pool, swapAmount);
+    uint256 expected2 = (swapAmount * 800) / 1_000_000;
+    assertEq(fee2, expected2, "Swap 2: must collect exactly 800 pips");
+
+    // Verify fee2 is higher than fee1 by the expected ratio (800/500 = 1.6x)
+    assertEq(fee2, (fee1 * 800) / 500, "Fee must scale exactly with rate change");
+
+    // === Change to zero (disabled) ===
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, 0);
+    v4FeeAdapter.applyFee(pool);
+
+    (,, protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, poolId);
+    assertEq(protocolFee, 0, "Fee should be 0");
+
+    // === Swap 3: Zero fee ===
+    uint256 feesBefore = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+    vm.deal(address(swapHelper), swapAmount);
+    vm.prank(address(swapHelper));
+    swapHelper.swap{value: swapAmount}(pool, SwapParams({
+      zeroForOne: true,
+      amountSpecified: -int256(swapAmount),
+      sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+    }));
+    uint256 feesAfter = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+
+    assertEq(feesAfter, feesBefore, "Swap 3: should collect zero fees when disabled");
+  }
+
+  /// @notice Verify fee accumulation across multiple swaps is additive
+  function test_swap_feesAccumulateCorrectly() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC, 500 pips
+    uint256 swapAmount = 0.5 ether;
+    uint256 expectedFeePerSwap = (swapAmount * 500) / 1_000_000;
+
+    uint256 initialFees = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+
+    // Perform 5 swaps
+    for (uint256 i = 0; i < 5; i++) {
+      vm.deal(address(swapHelper), swapAmount);
+      vm.prank(address(swapHelper));
+      swapHelper.swap{value: swapAmount}(pool, SwapParams({
+        zeroForOne: true,
+        amountSpecified: -int256(swapAmount),
+        sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+      }));
+    }
+
+    uint256 finalFees = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+    uint256 totalCollected = finalFees - initialFees;
+    uint256 expectedTotal = expectedFeePerSwap * 5;
+
+    assertEq(totalCollected, expectedTotal, "Total fees must exactly equal sum of individual fees");
+  }
+
+  /// @notice Test various swap sizes on ETH/USDC (500 pips tier fee)
+  function test_swap_variousSizes_tierFee() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC, 500 pips
+    uint24 feePips = 500;
+
+    // Test small swap: 0.001 ETH
+    uint256 smallAmount = 0.001 ether;
+    uint256 smallFee = _swapAndGetFee(pool, smallAmount);
+    assertEq(smallFee, (smallAmount * feePips) / 1_000_000, "Small swap: 0.001 ETH");
+
+    // Test medium swap: 0.1 ETH
+    uint256 mediumAmount = 0.1 ether;
+    uint256 mediumFee = _swapAndGetFee(pool, mediumAmount);
+    assertEq(mediumFee, (mediumAmount * feePips) / 1_000_000, "Medium swap: 0.1 ETH");
+
+    // Test large swap: 10 ETH
+    uint256 largeAmount = 10 ether;
+    uint256 largeFee = _swapAndGetFee(pool, largeAmount);
+    assertEq(largeFee, (largeAmount * feePips) / 1_000_000, "Large swap: 10 ETH");
+
+    // Test large swap: 20 ETH
+    uint256 veryLargeAmount = 20 ether;
+    uint256 veryLargeFee = _swapAndGetFee(pool, veryLargeAmount);
+    assertEq(veryLargeFee, (veryLargeAmount * feePips) / 1_000_000, "Large swap: 20 ETH");
+
+    // Test odd amount: 1.234567 ETH
+    uint256 oddAmount = 1.234567 ether;
+    uint256 oddFee = _swapAndGetFee(pool, oddAmount);
+    assertEq(oddFee, (oddAmount * feePips) / 1_000_000, "Odd swap: 1.234567 ETH");
+
+    // Test another odd amount: 7.891234 ETH
+    uint256 oddAmount2 = 7.891234 ether;
+    uint256 oddFee2 = _swapAndGetFee(pool, oddAmount2);
+    assertEq(oddFee2, (oddAmount2 * feePips) / 1_000_000, "Odd swap: 7.891234 ETH");
+  }
+
+  /// @notice Test various swap sizes with pool override (custom 333 pips)
+  function test_swap_variousSizes_poolOverride() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC
+    PoolId poolId = pool.toId();
+    uint24 customFee = 333; // Custom override
+
+    // Set pool override
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, customFee);
+    v4FeeAdapter.applyFee(pool);
+
+    // Verify override is set
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, poolId);
+    assertEq(protocolFee, _packFee(customFee), "Pool override should be set");
+
+    // Test various sizes
+    uint256[] memory amounts = new uint256[](5);
+    amounts[0] = 0.005 ether;
+    amounts[1] = 0.05 ether;
+    amounts[2] = 0.5 ether;
+    amounts[3] = 5 ether;
+    amounts[4] = 50 ether;
+
+    for (uint256 i = 0; i < amounts.length; i++) {
+      uint256 fee = _swapAndGetFee(pool, amounts[i]);
+      uint256 expected = (amounts[i] * customFee) / 1_000_000;
+      assertEq(fee, expected, string.concat("Override fee at size ", vm.toString(i)));
+    }
+  }
+
+  /// @notice Test swap fees on all tier pools to verify tier-specific rates
+  /// @dev V4 has internal rounding that can cause fees to be 1 unit lower than expected
+  ///      for certain input amounts. We verify the fee is within 1 unit of expected.
+  function test_swap_allPools_tierFees() public {
+    _executeV4Proposal();
+
+    // Pool 0: ETH/USDC (3000 tier) → 500 pips
+    {
+      PoolKey memory pool = testPools[0];
+      uint256 swapAmount = 2 ether;
+      uint256 fee = _swapAndGetFee(pool, swapAmount);
+      uint256 expected = (swapAmount * 500) / 1_000_000;
+      assertEq(fee, expected, "ETH/USDC: 500 pips");
+    }
+
+    // Pool 1: WBTC/cbBTC (100 tier) → 25 pips
+    {
+      PoolKey memory pool = testPools[1];
+      uint24 expectedPips = 25;
+      uint256 swapAmount = 1e8; // 1 WBTC (8 decimals)
+
+      // Deal WBTC to swapHelper and approve
+      deal(WBTC, address(swapHelper), swapAmount);
+      vm.prank(address(swapHelper));
+      IERC20(WBTC).approve(address(swapHelper), swapAmount);
+
+      uint256 fee = _swapERC20AndGetFee(pool, swapAmount, true);
+      uint256 expected = (swapAmount * expectedPips) / 1_000_000;
+      assertApproxEqAbs(fee, expected, 1, "WBTC/cbBTC: 25 pips");
+    }
+
+    // Pool 2: USDC/USDT (10 tier) → 3 pips
+    {
+      PoolKey memory pool = testPools[2];
+      uint24 expectedPips = 3;
+      uint256 swapAmount = 10_000e6; // 10,000 USDC (6 decimals)
+
+      // Deal USDC to swapHelper and approve
+      deal(USDC, address(swapHelper), swapAmount);
+      vm.prank(address(swapHelper));
+      IERC20(USDC).approve(address(swapHelper), swapAmount);
+
+      uint256 fee = _swapERC20AndGetFee(pool, swapAmount, true);
+      uint256 expected = (swapAmount * expectedPips) / 1_000_000;
+      assertApproxEqAbs(fee, expected, 1, "USDC/USDT 10: 3 pips");
+    }
+
+    // Pool 3: USDE/USDT (45 tier) → 11 pips
+    {
+      PoolKey memory pool = testPools[3];
+      uint24 expectedPips = 11;
+      uint256 swapAmount = 10_000e18; // 10,000 USDE (18 decimals)
+
+      // Deal USDE to swapHelper and approve
+      deal(USDE, address(swapHelper), swapAmount);
+      vm.prank(address(swapHelper));
+      IERC20(USDE).approve(address(swapHelper), swapAmount);
+
+      uint256 fee = _swapERC20AndGetFee(pool, swapAmount, true);
+      uint256 expected = (swapAmount * expectedPips) / 1_000_000;
+      assertApproxEqAbs(fee, expected, 1, "USDE/USDT: 11 pips");
+    }
+
+    // Pool 4: USDC/USDT (8 tier) → 2 pips
+    {
+      PoolKey memory pool = testPools[4];
+      uint24 expectedPips = 2;
+      uint256 swapAmount = 50_000e6; // 50,000 USDC (6 decimals)
+
+      // Deal USDC to swapHelper and approve
+      deal(USDC, address(swapHelper), swapAmount);
+      vm.prank(address(swapHelper));
+      IERC20(USDC).approve(address(swapHelper), swapAmount);
+
+      uint256 fee = _swapERC20AndGetFee(pool, swapAmount, true);
+      uint256 expected = (swapAmount * expectedPips) / 1_000_000;
+      assertApproxEqAbs(fee, expected, 1, "USDC/USDT 8: 2 pips");
+    }
+  }
+
+  /// @notice Test minimum fee edge case (1 wei input with low fee rate)
+  function test_swap_minimumFee_edgeCase() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC, 500 pips
+
+    // 1 wei * 500 / 1_000_000 = 0 (rounds down)
+    uint256 tinyAmount = 1 wei;
+    uint256 tinyFee = _swapAndGetFee(pool, tinyAmount);
+    assertEq(tinyFee, 0, "1 wei should yield 0 fee due to rounding");
+
+    // 2000 wei * 500 / 1_000_000 = 1 wei
+    uint256 minForOneFee = 2000 wei;
+    uint256 minFee = _swapAndGetFee(pool, minForOneFee);
+    assertEq(minFee, 1, "2000 wei should yield exactly 1 wei fee");
+
+    // 1999 wei * 500 / 1_000_000 = 0 (rounds down)
+    uint256 justUnder = 1999 wei;
+    uint256 justUnderFee = _swapAndGetFee(pool, justUnder);
+    assertEq(justUnderFee, 0, "1999 wei should yield 0 fee");
+  }
+
+  /// @notice Test maximum protocol fee rate (1000 pips = 0.1%)
+  function test_swap_maxFeeRate() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC
+    PoolId poolId = pool.toId();
+
+    // Set to max allowed fee (1000 pips)
+    uint24 maxFee = 1000;
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, maxFee);
+    v4FeeAdapter.applyFee(pool);
+
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, poolId);
+    assertEq(protocolFee, _packFee(maxFee), "Max fee should be set");
+
+    // Test various amounts at max fee rate
+    uint256 amount1 = 1 ether;
+    uint256 fee1 = _swapAndGetFee(pool, amount1);
+    assertEq(fee1, (amount1 * maxFee) / 1_000_000, "1 ETH at max fee");
+    assertEq(fee1, 0.001 ether, "1 ETH * 0.1% = 0.001 ETH");
+
+    uint256 amount10 = 10 ether;
+    uint256 fee10 = _swapAndGetFee(pool, amount10);
+    assertEq(fee10, (amount10 * maxFee) / 1_000_000, "10 ETH at max fee");
+    assertEq(fee10, 0.01 ether, "10 ETH * 0.1% = 0.01 ETH");
+  }
+
+  /// @notice Document V4's internal rounding behavior on very large swaps
+  /// @dev At 100 ETH, V4 rounds down by 1 wei due to internal precision limits
+  function test_swap_v4InternalRounding() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC, 500 pips
+    uint24 feePips = 500;
+
+    // 100 ETH swap shows V4's internal rounding: off by 1 wei
+    uint256 largeAmount = 100 ether;
+    uint256 fee = _swapAndGetFee(pool, largeAmount);
+    uint256 expected = (largeAmount * feePips) / 1_000_000;
+
+    // Document the actual behavior: V4 rounds down by 1 wei
+    assertEq(expected, 50000000000000000, "Expected: 0.05 ETH");
+    assertEq(fee, 49999999999999999, "Actual: 0.05 ETH - 1 wei (V4 rounding)");
+    assertEq(expected - fee, 1, "Difference is exactly 1 wei");
+  }
+
+  /// @notice Test fee collection with pool override vs tier override comparison
+  function test_swap_overrideComparison() public {
+    _executeV4Proposal();
+
+    PoolKey memory pool = testPools[0]; // ETH/USDC
+    PoolId poolId = pool.toId();
+    uint256 swapAmount = 5 ether;
+
+    // Swap 1: Tier fee (500 pips)
+    uint256 tierFee = _swapAndGetFee(pool, swapAmount);
+    uint256 expectedTier = (swapAmount * 500) / 1_000_000;
+    assertEq(tierFee, expectedTier, "Tier fee: 500 pips");
+
+    // Swap 2: Pool override lower (250 pips)
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, 250);
+    v4FeeAdapter.applyFee(pool);
+
+    uint256 lowerFee = _swapAndGetFee(pool, swapAmount);
+    uint256 expectedLower = (swapAmount * 250) / 1_000_000;
+    assertEq(lowerFee, expectedLower, "Pool override: 250 pips");
+    assertEq(lowerFee, tierFee / 2, "250 pips is exactly half of 500 pips");
+
+    // Swap 3: Pool override higher (750 pips)
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.setPoolOverride(poolId, 750);
+    v4FeeAdapter.applyFee(pool);
+
+    uint256 higherFee = _swapAndGetFee(pool, swapAmount);
+    uint256 expectedHigher = (swapAmount * 750) / 1_000_000;
+    assertEq(higherFee, expectedHigher, "Pool override: 750 pips");
+    assertEq(higherFee, (tierFee * 3) / 2, "750 pips is 1.5x of 500 pips");
+
+    // Swap 4: Clear override, back to tier
+    vm.prank(poolManagerOwner);
+    v4FeeAdapter.clearPoolOverride(poolId);
+    v4FeeAdapter.applyFee(pool);
+
+    uint256 backToTier = _swapAndGetFee(pool, swapAmount);
+    assertEq(backToTier, tierFee, "Back to tier fee after clearing override");
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //                    SWAP TEST HELPERS
+  // ═══════════════════════════════════════════════════════════════
+
+  /// @notice Execute an ETH swap and return the protocol fee collected
+  function _swapAndGetFee(PoolKey memory pool, uint256 swapAmount) internal returns (uint256 feeCollected) {
+    uint256 feesBefore = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+
+    vm.deal(address(swapHelper), swapAmount);
+    vm.prank(address(swapHelper));
+    swapHelper.swap{value: swapAmount}(pool, SwapParams({
+      zeroForOne: true,
+      amountSpecified: -int256(swapAmount),
+      sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+    }));
+
+    uint256 feesAfter = POOL_MANAGER.protocolFeesAccrued(pool.currency0);
+    feeCollected = feesAfter - feesBefore;
+  }
+
+  /// @notice Execute an ERC20 swap and return the protocol fee collected
+  /// @param pool The pool to swap on
+  /// @param swapAmount The amount of input token to swap
+  /// @param zeroForOne Direction of swap (true = token0 -> token1)
+  function _swapERC20AndGetFee(PoolKey memory pool, uint256 swapAmount, bool zeroForOne)
+    internal
+    returns (uint256 feeCollected)
+  {
+    Currency inputCurrency = zeroForOne ? pool.currency0 : pool.currency1;
+    uint256 feesBefore = POOL_MANAGER.protocolFeesAccrued(inputCurrency);
+
+    vm.prank(address(swapHelper));
+    swapHelper.swap(pool, SwapParams({
+      zeroForOne: zeroForOne,
+      amountSpecified: -int256(swapAmount),
+      sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+    }));
+
+    uint256 feesAfter = POOL_MANAGER.protocolFeesAccrued(inputCurrency);
+    feeCollected = feesAfter - feesBefore;
+  }
+
+  /// @notice Verify a pool's fee rate by checking the set protocol fee
+  function _verifyPoolFeeRate(PoolKey memory pool, uint24 expectedPips, string memory label) internal view {
+    (,, uint24 protocolFee,) = StateLibrary.getSlot0(POOL_MANAGER, pool.toId());
+    assertEq(protocolFee, _packFee(expectedPips), string.concat(label, ": incorrect protocol fee"));
+  }
+
+  function _executeV4Proposal() internal {
+    V4FeeSwitchProposal proposal = new V4FeeSwitchProposal();
+
+    // Execute the proposal as the PoolManager owner
+    proposal.runPranked(v4FeeAdapter, testPools, poolManagerOwner);
+  }
+}


### PR DESCRIPTION
This PR introduces tiered protocol fee support for Uniswap V4, enabling governance to collect protocol fees from V4 pools with a waterfall resolution pattern matching the V3 fee structure established in the UNIfication proposal.

## Summary
- V4FeeAdapter contract implementing tiered protocol fees with waterfall resolution: pool override → fee tier → default
- Governance proposal script to activate V4 fees and set the adapter as protocol fee controller
- Deployer contracts for Mainnet and Unichain
- Comprehensive unit and fork tests with exact fee validation

## Changes

### New Contracts
- src/feeAdapters/V4FeeAdapter.sol - Tiered fee controller with waterfall resolution
- src/interfaces/IV4FeeAdapter.sol - Interface with comprehensive NatSpec

### Scripts
- script/05_V4FeeSwitchProposal.s.sol - Governance proposal to activate fees
- script/06_DeployV4Mainnet.s.sol - Mainnet deployment script
- script/07_DeployV4Unichain.s.sol - Unichain deployment script
- script/deployers/V4MainnetDeployer.sol - Mainnet deployer contract
- script/deployers/V4UnichainDeployer.sol - Unichain deployer contract

### Tests
- test/V4FeeAdapter.t.sol - unit tests covering all V4 fee adapter functionality
- test/V4ProtocolFees.fork.t.sol - fork tests validating against real V4 pool interactions

## Technical Notes
- protocol fee values are packed (lower 12 bits for zeroForOne, upper 12 bits for oneForZero swaps)
- The adapter stores single-direction fees and packs them symmetrically when queried
- Uses `uint24.max` as sentinel for "explicitly zero fee" (distinct from "not set")
- Fork tests validate exact fee collection with 1 wei tolerance for V4's internal rounding