### PR TITLE
feat: add L2 deployment addresses and propagate-fees CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Uniswap Fee Collection
 
-*A unified system for collecting and converting fees from arbitrary revenue sources on arbitrary chains.*
+_A unified system for collecting and converting fees from arbitrary revenue sources on arbitrary chains._
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Goals](#goals)
 - [Architecture](#architecture)
@@ -10,20 +11,19 @@
 - [Fault Tolerance](#fault-tolerance)
 - [Deployment Architecture](#deployment-architecture)
 - [Development](#development)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
-    - [Testing](#testing)
-    - [Project Structure](#project-structure)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Testing](#testing)
+  - [Project Structure](#project-structure)
 - [Governance Proposal](#governance-proposal)
 - [Security](#security)
 - [Future Development](#future-development)
-    - [Protocol Fee Auctions](#protocol-fee-auctions)
-    - [Additional Protocol Support](#additional-protocol-support)
-    - [Cross-chain Expansion](#cross-chain-expansion)
+  - [Protocol Fee Auctions](#protocol-fee-auctions)
+  - [Additional Protocol Support](#additional-protocol-support)
+  - [Cross-chain Expansion](#cross-chain-expansion)
 - [Contributing](#contributing)
 - [License](#license)
 - [Support](#support)
-
 
 ## Overview
 
@@ -145,6 +145,7 @@ For OP Stack L2 chains (Unichain, Optimism, Base, etc.) where only bridged UNI e
 The `OptimismBridgedResourceFirepit` implements a two-stage burn process:
 
 **Stage 1 - L2 Collection:**
+
 1. Searcher calls `release()` with the current nonce, assets to release, and recipient
 2. Searcher pays a fixed amount of bridged UNI tokens
 3. UNI is transferred to the Firepit contract (not burned yet)
@@ -166,12 +167,12 @@ The `OptimismBridgedResourceFirepit` implements a two-stage burn process:
 
 **Configuration:**
 
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| RESOURCE | Bridged UNI | OptimismMintableERC20 token on L2 |
-| THRESHOLD | 2000 UNI | Amount required per release |
-| WITHDRAWAL_MIN_GAS | 100,000 | Gas for L1 transfer to burn address |
-| L1_RESOURCE_RECIPIENT | `0xdead` | Final burn destination on mainnet |
+| Parameter             | Value       | Description                         |
+| --------------------- | ----------- | ----------------------------------- |
+| RESOURCE              | Bridged UNI | OptimismMintableERC20 token on L2   |
+| THRESHOLD             | 2000 UNI    | Amount required per release         |
+| WITHDRAWAL_MIN_GAS    | 100,000     | Gas for L1 transfer to burn address |
+| L1_RESOURCE_RECIPIENT | `0xdead`    | Final burn destination on mainnet   |
 
 #### (Future) Hub-and-Spoke Cross-Chain
 
@@ -216,24 +217,100 @@ Ethereum Mainnet
 
 ### Ethereum Mainnet (Chain ID: 1)
 
-| Contract | Address |
-|----------|---------|
-| MainnetDeployer | [`0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C`](https://etherscan.io/address/0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C) |
-| TokenJar | [`0xf38521f130fcCF29dB1961597bc5d2B60F995f85`](https://etherscan.io/address/0xf38521f130fcCF29dB1961597bc5d2B60F995f85) |
+| Contract           | Address                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| MainnetDeployer    | [`0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C`](https://etherscan.io/address/0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C) |
+| TokenJar           | [`0xf38521f130fcCF29dB1961597bc5d2B60F995f85`](https://etherscan.io/address/0xf38521f130fcCF29dB1961597bc5d2B60F995f85) |
 | Releaser (Firepit) | [`0x0D5Cd355e2aBEB8fb1552F56c965B867346d6721`](https://etherscan.io/address/0x0D5Cd355e2aBEB8fb1552F56c965B867346d6721) |
-| V3FeeAdapter | [`0x5E74C9f42EEd283bFf3744fBD1889d398d40867d`](https://etherscan.io/address/0x5E74C9f42EEd283bFf3744fBD1889d398d40867d) |
-| UNI Vesting | [`0xCa046A83EDB78F74aE338bb5A291bF6FdAc9e1D2`](https://etherscan.io/address/0xCa046A83EDB78F74aE338bb5A291bF6FdAc9e1D2) |
+| V3FeeAdapter       | [`0x5E74C9f42EEd283bFf3744fBD1889d398d40867d`](https://etherscan.io/address/0x5E74C9f42EEd283bFf3744fBD1889d398d40867d) |
+| V3OpenFeeAdapter   | [`0xf2371551Fe3937Db7c750f4DfABe5c2fFFdcBf5A`](https://etherscan.io/address/0xf2371551Fe3937Db7c750f4DfABe5c2fFFdcBf5A) |
+| UNI Vesting        | [`0xCa046A83EDB78F74aE338bb5A291bF6FdAc9e1D2`](https://etherscan.io/address/0xCa046A83EDB78F74aE338bb5A291bF6FdAc9e1D2) |
 | Agreement Anchor 1 | [`0xC707467e7fb43Fe7Cc55264F892Dd2D7f8Fc27C8`](https://etherscan.io/address/0xC707467e7fb43Fe7Cc55264F892Dd2D7f8Fc27C8) |
 | Agreement Anchor 2 | [`0x33A56942Fe57f3697FE0fF52aB16cb0ba9b8eadd`](https://etherscan.io/address/0x33A56942Fe57f3697FE0fF52aB16cb0ba9b8eadd) |
 | Agreement Anchor 3 | [`0xF9F85a17cC6De9150Cd139f64b127976a1dE91D1`](https://etherscan.io/address/0xF9F85a17cC6De9150Cd139f64b127976a1dE91D1) |
 
 ### Unichain (Chain ID: 130)
 
-| Contract | Address |
-|----------|---------|
-| UnichainDeployer | [`0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea`](https://uniscan.xyz/address/0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea) |
-| TokenJar | [`0xD576BDF6b560079a4c204f7644e556DbB19140b5`](https://uniscan.xyz/address/0xD576BDF6b560079a4c204f7644e556DbB19140b5) |
+| Contract                                  | Address                                                                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| UnichainDeployer                          | [`0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea`](https://uniscan.xyz/address/0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea) |
+| TokenJar                                  | [`0xD576BDF6b560079a4c204f7644e556DbB19140b5`](https://uniscan.xyz/address/0xD576BDF6b560079a4c204f7644e556DbB19140b5) |
 | Releaser (OptimismBridgedResourceFirepit) | [`0xe0A780E9105aC10Ee304448224Eb4A2b11A77eeB`](https://uniscan.xyz/address/0xe0A780E9105aC10Ee304448224Eb4A2b11A77eeB) |
+
+### World Chain (Chain ID: 480)
+
+| Contract                                  | Address                                                                                                                  |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Deployer                                  | [`0x4E524DAbf30A1D6e87261c804991119181F65bb8`](https://worldscan.org/address/0x4E524DAbf30A1D6e87261c804991119181F65bb8) |
+| TokenJar                                  | [`0xbDb82c2dE7D8748A3e499e771604ef8ef8544918`](https://worldscan.org/address/0xbDb82c2dE7D8748A3e499e771604ef8ef8544918) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0x455e844D286631566cF98D6cb2996149734618C6`](https://worldscan.org/address/0x455e844D286631566cF98D6cb2996149734618C6) |
+| V3OpenFeeAdapter                          | [`0x1CE9d4DfB474Ef9ea7dc0e804a333202e40d6201`](https://worldscan.org/address/0x1CE9d4DfB474Ef9ea7dc0e804a333202e40d6201) |
+
+### Soneium (Chain ID: 1868)
+
+| Contract                                  | Address                                                                                                                           |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| CrossChainAccount                         | [`0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7`](https://soneium.blockscout.com/address/0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7) |
+| Deployer                                  | [`0xD63fFE536bE3f44AE8f33C5f9c81581f9C94d1C8`](https://soneium.blockscout.com/address/0xD63fFE536bE3f44AE8f33C5f9c81581f9C94d1C8) |
+| TokenJar                                  | [`0x85aeb792b94a9d79741002FC871423Ec5dAD29e9`](https://soneium.blockscout.com/address/0x85aeb792b94a9d79741002FC871423Ec5dAD29e9) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0xc9CC50A75cE2a5f88fa77B43e3b050480c731b6e`](https://soneium.blockscout.com/address/0xc9CC50A75cE2a5f88fa77B43e3b050480c731b6e) |
+| V3OpenFeeAdapter                          | [`0x47Cf920815344Fd684A48BBEFcbfbed9C7AE09CF`](https://soneium.blockscout.com/address/0x47Cf920815344Fd684A48BBEFcbfbed9C7AE09CF) |
+
+### Celo (Chain ID: 42220)
+
+| Contract                                  | Address                                                                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| CrossChainAccount                         | [`0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7`](https://celoscan.io/address/0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7) |
+| Deployer                                  | [`0x91Df768dF14E94a3fCa42badBF1907E3a3b0240f`](https://celoscan.io/address/0x91Df768dF14E94a3fCa42badBF1907E3a3b0240f) |
+| TokenJar                                  | [`0x190c22c5085640D1cB60CeC88a4F736Acb59bb6B`](https://celoscan.io/address/0x190c22c5085640D1cB60CeC88a4F736Acb59bb6B) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0x2758FbaA228D7d3c41dD139F47dab1a27bF9bc25`](https://celoscan.io/address/0x2758FbaA228D7d3c41dD139F47dab1a27bF9bc25) |
+| V3OpenFeeAdapter                          | [`0xB9952C01830306ea2fAAe1505f6539BD260Bfc48`](https://celoscan.io/address/0xB9952C01830306ea2fAAe1505f6539BD260Bfc48) |
+
+### Zora (Chain ID: 7777777)
+
+| Contract                                  | Address                                                                                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Deployer                                  | [`0x71F14F2A8b827cD29453498d5AF24F605caee931`](https://explorer.zora.energy/address/0x71F14F2A8b827cD29453498d5AF24F605caee931) |
+| TokenJar                                  | [`0x4753C137002D802f45302b118E265c41140e73C2`](https://explorer.zora.energy/address/0x4753C137002D802f45302b118E265c41140e73C2) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0x2f98eD4D04e633169FbC941BFCc54E785853b143`](https://explorer.zora.energy/address/0x2f98eD4D04e633169FbC941BFCc54E785853b143) |
+| V3OpenFeeAdapter                          | [`0xbfc49b47637a4DC9b7B8dE8E71BF41E519103B95`](https://explorer.zora.energy/address/0xbfc49b47637a4DC9b7B8dE8E71BF41E519103B95) |
+
+### X Layer (Chain ID: 196)
+
+| Contract                                  | Address                                                                                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| CrossChainAccount                         | [`0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7`](https://www.oklink.com/xlayer/address/0x044aAF330d7fD6AE683EEc5c1C1d1fFf5196B6b7) |
+| Deployer                                  | [`0xC943dd90D459dB082D9e9C1baBf89D4Afe79E7E0`](https://www.oklink.com/xlayer/address/0xC943dd90D459dB082D9e9C1baBf89D4Afe79E7E0) |
+| TokenJar                                  | [`0x8Dd8B6D56e4a4A158EDbBfE7f2f703B8FFC1a754`](https://www.oklink.com/xlayer/address/0x8Dd8B6D56e4a4A158EDbBfE7f2f703B8FFC1a754) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0xe122E231cb52aea99690963Fd73E91e33E97468f`](https://www.oklink.com/xlayer/address/0xe122E231cb52aea99690963Fd73E91e33E97468f) |
+| V3OpenFeeAdapter                          | [`0x6A88EF2e6511CAFfE2D006e260e7A5d1E7D4d7D7`](https://www.oklink.com/xlayer/address/0x6A88EF2e6511CAFfE2D006e260e7A5d1E7D4d7D7) |
+
+### Arbitrum One (Chain ID: 42161)
+
+| Contract         | Address                                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Deployer         | [`0x3Ac66e1bfC79032C9deFCB23aE4DEe3F8c1630eb`](https://arbiscan.io/address/0x3Ac66e1bfC79032C9deFCB23aE4DEe3F8c1630eb) |
+| TokenJar         | [`0x95E337C5B155385945D407f5396387D0c2a3A263`](https://arbiscan.io/address/0x95E337C5B155385945D407f5396387D0c2a3A263) |
+| Releaser         | [`0xB8018422bcE25D82E70cB98FdA96a4f502D89427`](https://arbiscan.io/address/0xB8018422bcE25D82E70cB98FdA96a4f502D89427) |
+| V3OpenFeeAdapter | [`0xFF7aD5dA31fECdC678796c88B05926dB896b0699`](https://arbiscan.io/address/0xFF7aD5dA31fECdC678796c88B05926dB896b0699) |
+
+### OP Mainnet (Chain ID: 10)
+
+| Contract                                  | Address                                                                                                                            |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Deployer                                  | [`0x3398783D2ffE6F79B56dade84CEAea888C400da4`](https://optimistic.etherscan.io/address/0x3398783D2ffE6F79B56dade84CEAea888C400da4) |
+| TokenJar                                  | [`0xb13285DF724ea75f3f1E9912010B7e491dCd5EE3`](https://optimistic.etherscan.io/address/0xb13285DF724ea75f3f1E9912010B7e491dCd5EE3) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0x94460443Ca27FFC1baeCa61165fde18346C91AbD`](https://optimistic.etherscan.io/address/0x94460443Ca27FFC1baeCa61165fde18346C91AbD) |
+| V3OpenFeeAdapter                          | [`0xec23Cf5A1db3dcC6595385D28B2a4D9B52503Be4`](https://optimistic.etherscan.io/address/0xec23Cf5A1db3dcC6595385D28B2a4D9B52503Be4) |
+
+### Base (Chain ID: 8453)
+
+| Contract                                  | Address                                                                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Deployer                                  | [`0x076f84717f3601B8Cd177bb84b217A2679B38b7d`](https://basescan.org/address/0x076f84717f3601B8Cd177bb84b217A2679B38b7d) |
+| TokenJar                                  | [`0x9bD25e67bF390437C8fAF480AC735a27BcF6168c`](https://basescan.org/address/0x9bD25e67bF390437C8fAF480AC735a27BcF6168c) |
+| Releaser (OptimismBridgedResourceFirepit) | [`0xFf77c0ED0B6b13A20446969107E5867abc46f53a`](https://basescan.org/address/0xFf77c0ED0B6b13A20446969107E5867abc46f53a) |
+| V3OpenFeeAdapter                          | [`0xaBEA76658b205696d49B5F91b2a03536cB8A3bE1`](https://basescan.org/address/0xaBEA76658b205696d49B5F91b2a03536cB8A3bE1) |
 
 ## Development
 
@@ -311,17 +388,18 @@ For additional commentary and information please see Uniswap Governance Proposal
 With the system already deployed, Uniswap Governance can elect into the system by executing the following calls:
 
 | Contract         | Address                                                                                                               | Calldata                                                                     | function                               | function signature | parameters                                                                                                            |
-|------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|----------------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------|
-| UniswapV3Factory | [0x1F98431c8aD98523631AE4a59f267346ea31F984](https://etherscan.io/address/0x1f98431c8ad98523631ae4a59f267346ea31f984) | `0x13af40350000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc` | `setOwner(address _owner)`             | `0x13af4035`       | [0xTOKENJAR](https://etherscan.io/address/0xTOKENJAR)                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| UniswapV3Factory | [0x1F98431c8aD98523631AE4a59f267346ea31F984](https://etherscan.io/address/0x1f98431c8ad98523631ae4a59f267346ea31f984) | `0x13af40350000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc` | `setOwner(address _owner)`             | `0x13af4035`       | [0xTOKENJAR](https://etherscan.io/address/0xTOKENJAR)                                                                 |
 | FeeToSetter      | [0x18e433c7Bf8A2E1d0197CE5d8f9AFAda1A771360](https://etherscan.io/address/0x18e433c7Bf8A2E1d0197CE5d8f9AFAda1A771360) | `0xa2e74af60000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc` | `setFeeToSetter(address feeToSetter_)` | `0xa2e74af6`       | [0x1a9C8182C09F50C8318d769245beA52c32BE35BC](https://etherscan.io/address/0x1a9c8182c09f50c8318d769245bea52c32be35bc) |
-| UniswapV2Factory | [0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f](https://etherscan.io/address/0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f) | `0xf46901ed0000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc` | `setFeeTo(address _feeTo)`             | `0xf46901ed`       | [0xTOKENJAR](https://etherscan.io/address/0xTOKENJAR)                                                               |
+| UniswapV2Factory | [0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f](https://etherscan.io/address/0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f) | `0xf46901ed0000000000000000000000001a9c8182c09f50c8318d769245bea52c32be35bc` | `setFeeTo(address _feeTo)`             | `0xf46901ed`       | [0xTOKENJAR](https://etherscan.io/address/0xTOKENJAR)                                                                 |
 
 ## Security
 
 **Audits**:
 Audit reports available in [audit/](./audit/)
-  - OpenZeppelin
-  - Spearbit
+
+- OpenZeppelin
+- Spearbit
 
 ## Future Development
 
@@ -356,4 +434,3 @@ This project is licensed under AGPL-3.0-only.
 ## Support
 
 For questions or issues, please open an issue in the repository.
-

--- a/merkle-generator/package.json
+++ b/merkle-generator/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@uniswap/merkle-generator",
+  "name": "@uniswap/protocol-fees",
   "type": "module",
   "version": "0.0.0",
   "packageManager": "pnpm@10.17.1",
-  "description": "CLI tool for generating Merkle trees and proofs for Uniswap V3 fee adapter",
+  "description": "CLI tool for Uniswap protocol fee management - Merkle tree generation and fee propagation",
   "author": "Uniswap Labs",
   "license": "MIT",
   "funding": "https://github.com/sponsors/antfu",
@@ -23,7 +23,7 @@
   "module": "./dist/cli.js",
   "types": "./dist/cli.d.ts",
   "bin": {
-    "merkle-generator": "./dist/cli.js"
+    "protocol-fees": "./dist/cli.js"
   },
   "files": [
     "dist"

--- a/merkle-generator/src/abi.ts
+++ b/merkle-generator/src/abi.ts
@@ -1,0 +1,14 @@
+// Minimal ABIs for on-chain interactions
+
+export const V3_FACTORY_ABI = [
+  'event PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)',
+] as const;
+
+export const V3_POOL_ABI = [
+  'function slot0() external view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)',
+] as const;
+
+export const V3_OPEN_FEE_ADAPTER_ABI = [
+  'function getFee(address pool) external view returns (uint8 fee)',
+  'function batchTriggerFeeUpdateByPool(address[] calldata pools) external',
+] as const;

--- a/merkle-generator/src/cli.ts
+++ b/merkle-generator/src/cli.ts
@@ -3,13 +3,14 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { StandardMerkleTree } from '@openzeppelin/merkle-tree';
 import { Command } from 'commander';
+import { propagateFees } from './propagate-fees.js';
 import { formatAddress, parseCSV, sortTokenPair } from './utils.js';
 
 const program = new Command();
 
 program
-  .name('merkle-generator')
-  .description('CLI tool for generating Merkle trees and proofs for Uniswap V3 fee adapter')
+  .name('protocol-fees')
+  .description('CLI tool for Uniswap protocol fee management')
   .version('0.0.0');
 
 // Generate command
@@ -385,6 +386,34 @@ program
     }
     catch (error) {
       console.error('Error parsing pools:', error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  });
+
+// Propagate fees command
+program
+  .command('propagate-fees')
+  .description('Discover V3 pools and propagate protocol fees via V3OpenFeeAdapter')
+  .requiredOption('--rpc-url <url>', 'RPC endpoint URL')
+  .requiredOption('--adapter-address <address>', 'V3OpenFeeAdapter contract address')
+  .requiredOption('--factory-address <address>', 'Uniswap V3 Factory contract address')
+  .requiredOption('--private-key <key>', 'Private key for signing transactions')
+  .option('--batch-size <number>', 'Max pools per transaction', '500')
+  .option('--from-block <number>', 'Start block for event scanning', '0')
+  .option('--chunk-size <number>', 'Block range per getLogs request', '10000')
+  .action(async (options) => {
+    try {
+      await propagateFees({
+        rpcUrl: options.rpcUrl,
+        adapterAddress: options.adapterAddress,
+        factoryAddress: options.factoryAddress,
+        privateKey: options.privateKey,
+        batchSize: parseInt(options.batchSize),
+        fromBlock: parseInt(options.fromBlock),
+        chunkSize: parseInt(options.chunkSize),
+      });
+    } catch (error) {
+      console.error('Error:', error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
   });

--- a/merkle-generator/src/propagate-fees.ts
+++ b/merkle-generator/src/propagate-fees.ts
@@ -1,0 +1,191 @@
+import { Contract, JsonRpcProvider, Wallet } from 'ethers';
+
+import { V3_FACTORY_ABI, V3_OPEN_FEE_ADAPTER_ABI, V3_POOL_ABI } from './abi.js';
+
+/**
+ * Discover all V3 pool addresses by scanning PoolCreated events from the factory.
+ * Chunks the block range to respect RPC provider limits.
+ */
+export async function discoverPools(
+  factoryContract: Contract,
+  provider: JsonRpcProvider,
+  fromBlock: number,
+  chunkSize: number,
+): Promise<string[]> {
+  const latestBlock = await provider.getBlockNumber();
+  const poolSet = new Set<string>();
+
+  for (let start = fromBlock; start <= latestBlock; start += chunkSize) {
+    const end = Math.min(start + chunkSize - 1, latestBlock);
+    console.log(`  Scanning blocks ${start} - ${end}...`);
+
+    const events = await factoryContract.queryFilter(
+      factoryContract.filters.PoolCreated(),
+      start,
+      end,
+    );
+
+    for (const event of events) {
+      const poolAddress = (event as any).args[4] as string;
+      poolSet.add(poolAddress);
+    }
+  }
+
+  return Array.from(poolSet);
+}
+
+export interface PoolFeeStatus {
+  initialized: number;
+  uninitialized: number;
+  correct: number;
+  needsUpdate: string[];
+}
+
+/**
+ * Check each pool's current fee against the adapter's expected fee.
+ * Returns which pools need updates and summary counts.
+ */
+export async function checkFees(
+  pools: string[],
+  adapterContract: Contract,
+  createPoolContract: (address: string) => Contract,
+): Promise<PoolFeeStatus> {
+  let initialized = 0;
+  let uninitialized = 0;
+  let correct = 0;
+  const needsUpdate: string[] = [];
+
+  for (const pool of pools) {
+    const poolContract = createPoolContract(pool);
+    const slot0 = await poolContract.slot0();
+    const sqrtPriceX96 = slot0.sqrtPriceX96 ?? slot0[0];
+    const actualFee = Number(slot0.feeProtocol ?? slot0[5]);
+
+    if (sqrtPriceX96 === 0n) {
+      uninitialized++;
+      continue;
+    }
+
+    initialized++;
+
+    const expectedFee = Number(await adapterContract.getFee(pool));
+
+    if (actualFee === expectedFee) {
+      correct++;
+    }
+    else {
+      needsUpdate.push(pool);
+    }
+  }
+
+  return { initialized, uninitialized, correct, needsUpdate };
+}
+
+export interface BatchResult {
+  txHash: string;
+  gasUsed: bigint;
+  poolCount: number;
+}
+
+/**
+ * Send batchTriggerFeeUpdateByPool transactions in chunks.
+ * Waits for each tx receipt before proceeding.
+ */
+export async function executeBatchUpdate(
+  pools: string[],
+  adapterContract: Contract,
+  batchSize: number,
+): Promise<BatchResult[]> {
+  if (pools.length === 0) return [];
+
+  const results: BatchResult[] = [];
+
+  for (let i = 0; i < pools.length; i += batchSize) {
+    const batch = pools.slice(i, i + batchSize);
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const totalBatches = Math.ceil(pools.length / batchSize);
+
+    console.log(`  Batch ${batchNum}/${totalBatches}: ${batch.length} pools...`);
+
+    const tx = await adapterContract.batchTriggerFeeUpdateByPool(batch);
+    const receipt = await tx.wait();
+
+    results.push({
+      txHash: receipt.hash,
+      gasUsed: receipt.gasUsed,
+      poolCount: batch.length,
+    });
+
+    console.log(`    tx: ${receipt.hash}, gas: ${receipt.gasUsed}`);
+  }
+
+  return results;
+}
+
+export interface PropagateFeeOptions {
+  rpcUrl: string;
+  adapterAddress: string;
+  factoryAddress: string;
+  privateKey: string;
+  batchSize: number;
+  fromBlock: number;
+  chunkSize: number;
+}
+
+/**
+ * Main orchestrator: discover pools, check fees, batch-update incorrect ones.
+ */
+export async function propagateFees(options: PropagateFeeOptions): Promise<void> {
+  const provider = new JsonRpcProvider(options.rpcUrl);
+  const wallet = new Wallet(options.privateKey, provider);
+  const network = await provider.getNetwork();
+
+  console.log(`Chain ID: ${network.chainId}`);
+  console.log(`Factory: ${options.factoryAddress}`);
+  console.log(`Adapter: ${options.adapterAddress}`);
+  console.log(`Sender: ${wallet.address}`);
+  console.log('');
+
+  // 1. Discover pools
+  console.log('Step 1: Discovering pools...');
+  const factoryContract = new Contract(options.factoryAddress, V3_FACTORY_ABI, provider);
+  const pools = await discoverPools(factoryContract, provider, options.fromBlock, options.chunkSize);
+  console.log(`  Found ${pools.length} pools\n`);
+
+  if (pools.length === 0) {
+    console.log('No pools found. Done.');
+    return;
+  }
+
+  // 2. Check fees
+  console.log('Step 2: Checking pool fees...');
+  const adapterContract = new Contract(options.adapterAddress, V3_OPEN_FEE_ADAPTER_ABI, wallet);
+  const createPoolContract = (address: string) => new Contract(address, V3_POOL_ABI, provider);
+
+  const status = await checkFees(pools, adapterContract, createPoolContract);
+  console.log(`  Initialized: ${status.initialized}`);
+  console.log(`  Uninitialized: ${status.uninitialized}`);
+  console.log(`  Already correct: ${status.correct}`);
+  console.log(`  Needs update: ${status.needsUpdate.length}\n`);
+
+  if (status.needsUpdate.length === 0) {
+    console.log('All pools have correct fees. Done.');
+    return;
+  }
+
+  // 3. Execute batch updates
+  console.log('Step 3: Sending transactions...');
+  const results = await executeBatchUpdate(status.needsUpdate, adapterContract, options.batchSize);
+
+  // 4. Summary
+  console.log('\n=== Summary ===');
+  console.log(`Pools discovered: ${pools.length}`);
+  console.log(`Pools updated: ${status.needsUpdate.length}`);
+  console.log(`Transactions sent: ${results.length}`);
+  const totalGas = results.reduce((sum, r) => sum + r.gasUsed, 0n);
+  console.log(`Total gas used: ${totalGas}`);
+  for (const [i, result] of results.entries()) {
+    console.log(`  Batch ${i + 1}: ${result.poolCount} pools, tx ${result.txHash}, gas ${result.gasUsed}`);
+  }
+  console.log('\nDone. All pools now have correct protocol fees.');
+}

--- a/merkle-generator/test/propagate-fees.test.ts
+++ b/merkle-generator/test/propagate-fees.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkFees, discoverPools, executeBatchUpdate } from '../src/propagate-fees';
+
+describe('discoverPools', () => {
+  it('should extract pool addresses from PoolCreated events', async () => {
+    const mockLogs = [
+      {
+        args: [
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+          500n,
+          10n,
+          '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        ],
+      },
+      {
+        args: [
+          '0x3333333333333333333333333333333333333333',
+          '0x4444444444444444444444444444444444444444',
+          3000n,
+          60n,
+          '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+        ],
+      },
+    ];
+
+    const mockContract = {
+      queryFilter: vi.fn().mockResolvedValue(mockLogs),
+      filters: {
+        PoolCreated: vi.fn().mockReturnValue('PoolCreated'),
+      },
+    };
+
+    const mockProvider = {
+      getBlockNumber: vi.fn().mockResolvedValue(1000),
+    };
+
+    const pools = await discoverPools(
+      mockContract as any,
+      mockProvider as any,
+      0,
+      10000,
+    );
+
+    expect(pools).toEqual([
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    ]);
+  });
+
+  it('should chunk requests when block range exceeds chunk size', async () => {
+    const mockContract = {
+      queryFilter: vi.fn().mockResolvedValue([]),
+      filters: {
+        PoolCreated: vi.fn().mockReturnValue('PoolCreated'),
+      },
+    };
+
+    const mockProvider = {
+      getBlockNumber: vi.fn().mockResolvedValue(25000),
+    };
+
+    await discoverPools(mockContract as any, mockProvider as any, 0, 10000);
+
+    // Should make 3 calls: 0-9999, 10000-19999, 20000-25000
+    expect(mockContract.queryFilter).toHaveBeenCalledTimes(3);
+  });
+
+  it('should deduplicate pool addresses', async () => {
+    const duplicatePool = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const mockLogs = [
+      { args: ['0x1', '0x2', 500n, 10n, duplicatePool] },
+    ];
+
+    const mockContract = {
+      queryFilter: vi
+        .fn()
+        .mockResolvedValueOnce(mockLogs)
+        .mockResolvedValueOnce(mockLogs),
+      filters: {
+        PoolCreated: vi.fn().mockReturnValue('PoolCreated'),
+      },
+    };
+
+    const mockProvider = {
+      getBlockNumber: vi.fn().mockResolvedValue(15000),
+    };
+
+    const pools = await discoverPools(mockContract as any, mockProvider as any, 0, 10000);
+    expect(pools).toHaveLength(1);
+  });
+});
+
+describe('checkFees', () => {
+  it('should identify pools needing updates', async () => {
+    const pools = [
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    ];
+
+    // Pool A: initialized, fee correct (68 = 0x44)
+    // Pool B: initialized, fee wrong (0 vs expected 68)
+    // Pool C: uninitialized (sqrtPriceX96 = 0)
+    const mockSlot0Results = [
+      { sqrtPriceX96: 1000n, feeProtocol: 68n }, // correct
+      { sqrtPriceX96: 1000n, feeProtocol: 0n }, // wrong
+      { sqrtPriceX96: 0n, feeProtocol: 0n }, // uninitialized
+    ];
+
+    const mockGetFeeResults = [68, 68, 68];
+
+    const mockPoolContract = {
+      slot0: vi.fn(),
+    };
+    const mockAdapterContract = {
+      getFee: vi.fn(),
+    };
+
+    for (let i = 0; i < pools.length; i++) {
+      mockPoolContract.slot0.mockResolvedValueOnce(mockSlot0Results[i]);
+      mockAdapterContract.getFee.mockResolvedValueOnce(mockGetFeeResults[i]);
+    }
+
+    const createPoolContract = vi.fn().mockReturnValue(mockPoolContract);
+
+    const result = await checkFees(
+      pools,
+      mockAdapterContract as any,
+      createPoolContract,
+    );
+
+    expect(result.initialized).toBe(2);
+    expect(result.uninitialized).toBe(1);
+    expect(result.correct).toBe(1);
+    expect(result.needsUpdate).toEqual(['0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB']);
+  });
+});
+
+describe('executeBatchUpdate', () => {
+  it('should chunk pools into batches and send transactions', async () => {
+    const pools = Array.from({ length: 5 }, (_, i) =>
+      `0x${String(i).padStart(40, '0')}`);
+
+    const mockReceipt = { hash: '0xabc', gasUsed: 100000n };
+    const mockTx = { wait: vi.fn().mockResolvedValue(mockReceipt) };
+    const mockAdapterContract = {
+      batchTriggerFeeUpdateByPool: vi.fn().mockResolvedValue(mockTx),
+    };
+
+    const results = await executeBatchUpdate(
+      pools,
+      mockAdapterContract as any,
+      3,
+    );
+
+    expect(results).toHaveLength(2); // 3 + 2
+    expect(mockAdapterContract.batchTriggerFeeUpdateByPool).toHaveBeenCalledTimes(2);
+
+    // First batch: 3 pools
+    expect(mockAdapterContract.batchTriggerFeeUpdateByPool.mock.calls[0][0]).toHaveLength(3);
+    // Second batch: 2 pools
+    expect(mockAdapterContract.batchTriggerFeeUpdateByPool.mock.calls[1][0]).toHaveLength(2);
+  });
+
+  it('should return empty array when no pools need updates', async () => {
+    const mockAdapterContract = {
+      batchTriggerFeeUpdateByPool: vi.fn(),
+    };
+
+    const results = await executeBatchUpdate([], mockAdapterContract as any, 500);
+    expect(results).toHaveLength(0);
+    expect(mockAdapterContract.batchTriggerFeeUpdateByPool).not.toHaveBeenCalled();
+  });
+});

--- a/script/DeployV3OpenMainnet.s.sol
+++ b/script/DeployV3OpenMainnet.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {console2} from "forge-std/console2.sol";
+import "forge-std/Script.sol";
+import {V3OpenMainnetDeployer} from "./deployers/V3OpenMainnetDeployer.sol";
+
+contract DeployV3OpenMainnet is Script {
+  function setUp() public {}
+
+  function run() public {
+    require(block.chainid == 1, "Not mainnet");
+
+    vm.startBroadcast();
+
+    V3OpenMainnetDeployer deployer = new V3OpenMainnetDeployer{salt: bytes32(uint256(1))}();
+    console2.log("Deployed Deployer at:", address(deployer));
+    console2.log("V3_OPEN_FEE_ADAPTER at:", address(deployer.V3_OPEN_FEE_ADAPTER()));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/deployers/V3OpenMainnetDeployer.sol
+++ b/script/deployers/V3OpenMainnetDeployer.sol
@@ -52,6 +52,9 @@ contract V3OpenMainnetDeployer {
     // 2. Set this contract as feeSetter temporarily
     V3_OPEN_FEE_ADAPTER.setFeeSetter(address(this));
 
+    // Set default fee (applied when no tier or pool override is set)
+    V3_OPEN_FEE_ADAPTER.setDefaultFee(DEFAULT_FEE_100);
+
     // 3. Set default fees for each tier
     V3_OPEN_FEE_ADAPTER.setFeeTierDefault(100, DEFAULT_FEE_100);
     V3_OPEN_FEE_ADAPTER.setFeeTierDefault(500, DEFAULT_FEE_500);


### PR DESCRIPTION
<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Adds deployed contract addresses for mainnet V3OpenFeeAdapter and 8 L2 chains to README documentation, with supporting deployment script and a new CLI command for propagating protocol fees.
## Changes
**Documentation:**
- Add V3OpenFeeAdapter address (`0xf2371551Fe3937Db7c750f4DfABe5c2fFFdcBf5A`) to Ethereum Mainnet section
- Add deployment addresses for 8 L2 chains with block explorer links:
  - World Chain (480): Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - Soneium (1868): CrossChainAccount, Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - Celo (42220): CrossChainAccount, Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - Zora (7777777): Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - X Layer (196): CrossChainAccount, Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - Arbitrum One (42161): Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - OP Mainnet (10): Deployer, TokenJar, Releaser, V3OpenFeeAdapter
  - Base (8453): Deployer, TokenJar, Releaser, V3OpenFeeAdapter
**Deployment Scripts:**
- Add `script/DeployV3OpenMainnet.s.sol` for V3OpenFeeAdapter deployment
- Fix `V3OpenMainnetDeployer.sol` to set global default fee during deployment
**CLI Tooling:**
- Rename CLI from `merkle-generator` to `protocol-fees`
- Add `propagate-fees` command for discovering V3 pools and batch-updating protocol fees via V3OpenFeeAdapter
- Add `merkle-generator/src/abi.ts` with minimal contract ABIs
- Add `merkle-generator/src/propagate-fees.ts` implementing pool discovery, fee checking, and batch execution
- Add unit tests for propagate-fees functionality
## Notes
- Soneium, Celo, and X Layer include CrossChainAccount contracts for L2 governance
- The `propagate-fees` command scans PoolCreated events, checks current vs expected fees, and batch-updates pools with incorrect fees
- Markdown formatting fixes applied to README tables
<!-- claude-pr-description-end -->