### PR TITLE
fix(ci): grant required permissions to Claude review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
       custom_prompt_path: ".claude/prompts/claude-pr-review.md"
 
-      model: "claude-opus-4-6"
+      model: "claude-opus-4-7"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, ready_for_review, labeled, unlabeled]
 
 permissions:
-  contents: read
+  contents: write # required by ai-toolkit _claude-code-review.yml for the auto_fix feature
   pull-requests: write
   issues: read
   actions: read
@@ -27,13 +27,12 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
-      toolkit_ref: 9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
-      custom_prompt_path: ".claude/prompts/claude-pr-review.md"
+      toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
 
       model: "claude-opus-4-6"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,12 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, labeled, unlabeled]
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  actions: read
+  id-token: write
 
 jobs:
   claude-review-auto:
@@ -30,7 +35,7 @@ jobs:
       toolkit_ref: 9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
       custom_prompt_path: ".claude/prompts/claude-pr-review.md"
 
-      model: "claude-opus-4-5"
+      model: "claude-opus-4-6"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -22,7 +22,10 @@ concurrency:
   group: pr-metadata-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
 
 jobs:
   generate-pr-metadata:

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -40,7 +40,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- **Fix `startup_failure`**: Replace `permissions: {}` in `claude-code-review.yml` and `claude-pr-metadata-update.yml` with the explicit set the reusable workflows in `Uniswap/ai-toolkit` require. The empty scope was capping the GITHUB_TOKEN delegated to the called workflow at no permissions, which the reusable workflow's job-level `permissions:` block cannot satisfy, so every recent run terminated as `startup_failure` before producing any job (e.g. https://github.com/Uniswap/protocol-fees/actions/runs/25402872564). The pattern matches `Uniswap/initializer` (also `permissions: {}`, also fails every run); `Uniswap/universal-router` (no `permissions:` block, inherits repo default) and `Uniswap/universe` (explicit permissions block) both run the same reusable workflow successfully.
- **Fix invalid model**: `model: "claude-opus-4-5"` is not a real Anthropic model; bumped to `claude-opus-4-6`.
- **Bump pinned ai-toolkit SHA** in both workflows from `9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b` to `96ef665ba04221de07e94fcc3ea69fe32c7cf306` (current `Uniswap/ai-toolkit` `main` tip). For the metadata workflow this is a clean bump (inputs schema unchanged). For the review workflow:
  - The new SHA replaced `custom_prompt` / `custom_prompt_path` with granular `prompt_override_*` inputs (one per prompt section). Dropped `custom_prompt_path` so the workflow falls back to the toolkit's curated default prompt. Splitting `.claude/prompts/claude-pr-review.md` into `prompt_override_review_priorities`, `prompt_override_files_to_skip`, `prompt_override_communication_style`, etc. can land as a follow-up using the pattern in `Uniswap/universe` and `Uniswap/sdks`.
  - Bumped `contents` permission from `read` to `write`: the new SHA's job-level permissions request `contents: write` to support the `auto_fix` feature.

## Test plan

- [ ] On this PR, confirm `[claude] Claude Code Review` and `[claude] Generate PR Title & Description` complete without `startup_failure`.
- [ ] Confirm Claude posts a review (or a `COMMENT`-level review) on this PR.
- [ ] Confirm the metadata workflow generates / updates the PR description.