### PR TITLE
chore(deps): maintain Claude Code Action workflows (v1.0.133)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,15 +23,13 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
-      custom_prompt_path: ".claude/prompts/claude-pr-review.md"
-
-      model: "claude-opus-4-5"
+      model: "claude-opus-4-7"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -38,7 +38,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `824dfc1` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-7`
  - `sonnet` → `claude-sonnet-4-6`

### Per-file changes

#### `.github/workflows/claude-code-review.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `96ef665` → `824dfc1`
- **Breaking-change auto-fix:** removed deprecated input `custom_prompt_path` (no longer in Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml at the new SHA)
- Model bump: `claude-opus-4-5` → `claude-opus-4-7`

#### `.github/workflows/claude-pr-metadata-update.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `96ef665` → `824dfc1`

---

_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._