### PR TITLE
chore(deps): maintain Claude Code Action workflows (v1.0.133)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,15 +23,13 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
-      custom_prompt_path: ".claude/prompts/claude-pr-review.md"
-
-      model: "claude-opus-4-5"
+      model: "claude-opus-4-8"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9b405c71e42d0cec4026f2c158edf99716600baa
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,13 +23,13 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9b405c71e42d0cec4026f2c158edf99716600baa
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
-      model: "claude-opus-4-8"
+      model: "claude-opus-5"
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -38,7 +38,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9b405c71e42d0cec4026f2c158edf99716600baa
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -38,7 +38,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9b405c71e42d0cec4026f2c158edf99716600baa
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -38,7 +38,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `27e7e2d` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-8`
  - `sonnet` → `claude-sonnet-4-6`

### Per-file changes

#### `.github/workflows/claude-code-review.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `96ef665` → `27e7e2d`
- **Breaking-change auto-fix:** removed deprecated input `custom_prompt_path` (no longer in Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml at the new SHA)
- Model bump: `claude-opus-4-5` → `claude-opus-4-8`

#### `.github/workflows/claude-pr-metadata-update.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `96ef665` → `27e7e2d`

---

_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._