### PR TITLE
fix(proposal-6): WorldChain & XLayer v4 activation must use CrossChainAccount (XDM), not OptimismPortal2

### DIFF
--- a/script/proposal-6/V4FeesProposal.s.sol
+++ b/script/proposal-6/V4FeesProposal.s.sol
@@ -12,10 +12,8 @@ import {GovernanceSeatbelt} from "govkit/forge/GovernanceSeatbelt.sol";
 import {FxRootEncoder} from "govkit/bridges/FxRootEncoder.sol";
 import {InboxEncoder} from "govkit/bridges/InboxEncoder.sol";
 import {L1CrossDomainMessengerEncoder} from "govkit/bridges/L1CrossDomainMessengerEncoder.sol";
-import {OptimismPortal2Encoder} from "govkit/bridges/OptimismPortal2Encoder.sol";
 import {WormholeEncoder} from "govkit/bridges/WormholeEncoder.sol";
 import {IPoolManager} from "govkit/interfaces/IPoolManager.sol";
-import {IL1CrossDomainMessenger} from "govkit/interfaces/bridges/IL1CrossDomainMessenger.sol";
 
 import "../proposal-5/Constants.sol" as Constants;
 
@@ -199,8 +197,9 @@ contract V4FeeProposal is Script {
       // ---------------------------------------------------------------------------------------------
       // 02: Activate V4 Fees for Worldchain.
       //
-      Call memory activateV4FeesWorldchain = OptimismPortal2Encoder.encode({
-        portal: IL1CrossDomainMessenger(uniswap.ethereum.bridge.worldChain).portal(),
+      Call memory activateV4FeesWorldchain = L1CrossDomainMessengerEncoder.encode({
+        l1CrossDomainMessenger: uniswap.ethereum.bridge.worldChain,
+        crossChainAccount: uniswap.worldChain.crossChainAccount,
         remoteCall: Call({
           target: uniswap.worldChain.poolManager,
           value: 0,
@@ -214,8 +213,9 @@ contract V4FeeProposal is Script {
       // ---------------------------------------------------------------------------------------------
       // 03: Activate V4 Fees for X Layer
       //
-      Call memory activateV4FeesXLayer = OptimismPortal2Encoder.encode({
-        portal: IL1CrossDomainMessenger(uniswap.ethereum.bridge.xLayer).portal(),
+      Call memory activateV4FeesXLayer = L1CrossDomainMessengerEncoder.encode({
+        l1CrossDomainMessenger: uniswap.ethereum.bridge.xLayer,
+        crossChainAccount: uniswap.xLayer.crossChainAccount,
         remoteCall: Call({
           target: uniswap.xLayer.poolManager,
           value: 0,


### PR DESCRIPTION
## Summary

The v4 fee **activation** proposal (`V4FeeProposal` in `script/proposal-6/V4FeesProposal.s.sol`) activates WorldChain and XLayer via `OptimismPortal2Encoder`, which delivers `setProtocolFeeController` from the **aliased Timelock**. But both PoolManagers are owned by their **CrossChainAccount**, so the L2 call reverts on `onlyOwner` — the L1 proposal executes "successfully" while v4 fees **silently never activate** on those two chains. Because it's an OP-stack deposit (not an Arbitrum retryable), the spent message can't be retried without a fresh governance vote.

This switches both to `L1CrossDomainMessengerEncoder` → `CrossChainAccount.forward`, matching the five other OP-stack chains (Base/Celo/Optimism/Soneium/Zora).

## Onchain verification

Verified `owner()` on all reachable target PoolManagers against the L2 sender each encoder produces — **only WorldChain and XLayer were mismatched**; the other 9 already line up. Full authority chain for the two fixed chains:

| Chain | PoolManager `.owner()` | CrossChainAccount `l1Owner` | `messenger` |
|---|---|---|---|
| WorldChain | its CrossChainAccount ✓ | mainnet Timelock ✓ | L2CrossDomainMessenger ✓ |
| XLayer | its CrossChainAccount ✓ | mainnet Timelock ✓ | L2CrossDomainMessenger ✓ |

i.e. `Timelock → L1CrossDomainMessenger → CrossChainAccount (owned by Timelock) → forward → PoolManager` resolves cleanly. The previously-used `OptimismPortal2` (aliased-Timelock) path does not, because aliased-Timelock ≠ owner.

## Changes
- WorldChain & XLayer activation → `L1CrossDomainMessengerEncoder`
- Removed the now-unused `OptimismPortal2Encoder` and `IL1CrossDomainMessenger` imports
- `forge build` passes; `V4FeeProposal` compiles

## Note
This only affects **Part 2** of the activation (WorldChain/XLayer are both in Part 2). Part 1 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)