### PR TITLE
fix: address OpenZeppelin FeeDripper audit findings

### DIFF
--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.29;
+pragma solidity 0.8.29;
 
 import {Currency} from "v4-core/types/Currency.sol";
 import {Owned} from "solmate/src/auth/Owned.sol";

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -13,7 +13,7 @@ import {IFeeDripper} from "../interfaces/IFeeDripper.sol";
 /// @custom:security-contact security@uniswap.org
 contract FeeDripper is Owned, IFeeDripper {
   /// @notice Basis points denominator
-  uint24 public constant BPS = 10_000;
+  uint16 public constant BPS = 10_000;
 
   // masks for the perBlockRate, endReleaseBlock, and latestReleaseBlock
   uint256 private constant UINT160_MASK = 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -220,7 +220,5 @@ contract FeeDripper is Owned, IFeeDripper {
       releasedAmount += postDripBalance;
       postDripBalance = 0;
     }
-
-    return (postDripBalance, releasedAmount, releaseWindow);
   }
 }

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -113,7 +113,7 @@ contract FeeDripper is Owned, IFeeDripper {
   receive() external payable {}
 
   /// @dev Transfers tokens to the token jar. Emits the Released event.
-  function _releaseTokens(Currency currency, uint256 releasedAmount) internal {
+  function _releaseTokens(Currency currency, uint256 releasedAmount) private {
     // Transfer released tokens to the token jar
     if (releasedAmount > 0) {
       currency.transfer(TOKEN_JAR, releasedAmount);
@@ -127,7 +127,7 @@ contract FeeDripper is Owned, IFeeDripper {
     uint160 perBlockRate,
     uint48 endReleaseBlock,
     uint48 latestReleaseBlock
-  ) internal {
+  ) private {
     // Used assembly to pack and store values directly from stack and skip memory allocation.
     assembly ("memory-safe") {
       mstore(0x00, currency)
@@ -146,7 +146,7 @@ contract FeeDripper is Owned, IFeeDripper {
 
   /// @dev Reads the drip state from storage. Skips memory and reads directly to stack
   function _readDripState(Currency currency)
-    internal
+    private
     view
     returns (uint160 perBlockRate, uint48 endReleaseBlock, uint48 latestReleaseBlock)
   {
@@ -164,7 +164,7 @@ contract FeeDripper is Owned, IFeeDripper {
 
   /// @dev Reads the release settings from storage. Skips memory and reads directly to stack
   function _readReleaseSettings()
-    internal
+    private
     view
     returns (uint16 releaseWindow, uint16 windowResetBps)
   {
@@ -181,7 +181,7 @@ contract FeeDripper is Owned, IFeeDripper {
     uint160 perBlockRate,
     uint48 endReleaseBlock,
     uint48 latestReleaseBlock
-  ) internal view returns (uint256 postDripBalance, uint256 releasedAmount, uint16 releaseWindow) {
+  ) private view returns (uint256 postDripBalance, uint256 releasedAmount, uint16 releaseWindow) {
     // Calculate the previous balance of the currency at last call
     uint256 previousBalance = (endReleaseBlock - latestReleaseBlock) * perBlockRate;
 

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -214,8 +214,9 @@ contract FeeDripper is Owned, IFeeDripper {
       }
     }
 
-    // If the remaining balance is less than the release window, immediately release the remaining
-    // balance to skip dust accumulation
+    // Flush when postDripBalance / originalReleaseWindow truncates to 0 (perBlockRate = 0).
+    // Without this, sub-divisor amounts are locked in the dripper.
+    // Note: compares token units against block count.
     if (postDripBalance < originalReleaseWindow) {
       releasedAmount += postDripBalance;
       postDripBalance = 0;

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -16,9 +16,9 @@ contract FeeDripper is Owned, IFeeDripper {
   uint24 public constant BPS = 10_000;
 
   // masks for the perBlockRate, endReleaseBlock, and latestReleaseBlock
-  uint256 constant UINT160_MASK = 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-  uint256 constant UINT48_MASK = 0xFFFFFFFFFFFF;
-  uint256 constant UINT16_MASK = 0xFFFF;
+  uint256 private constant UINT160_MASK = 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+  uint256 private constant UINT48_MASK = 0xFFFFFFFFFFFF;
+  uint256 private constant UINT16_MASK = 0xFFFF;
 
   // token jar address to receive the dripped fees
   address public immutable TOKEN_JAR;

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -12,6 +12,17 @@ import {IFeeDripper} from "../interfaces/IFeeDripper.sol";
 ///      PoolManager and CCA auctions, which also assume exact-amount transfers.
 /// @custom:security-contact security@uniswap.org
 contract FeeDripper is Owned, IFeeDripper {
+  struct ReleaseSettings {
+    uint16 releaseWindow; // the window of blocks over which the fees are released
+    uint16 windowResetBps; // min new-deposit-to-previous-balance ratio (in bps) to reset the window
+  }
+
+  struct Drip {
+    uint160 perBlockRate;
+    uint48 endReleaseBlock;
+    uint48 latestReleaseBlock;
+  }
+
   /// @notice Basis points denominator
   uint16 public constant BPS = 10_000;
 
@@ -27,17 +38,6 @@ contract FeeDripper is Owned, IFeeDripper {
     ReleaseSettings({releaseWindow: 2000, windowResetBps: 50});
   // mapping of currency to drip
   mapping(Currency => Drip) public drips;
-
-  struct ReleaseSettings {
-    uint16 releaseWindow; // the window of blocks over which the fees are released
-    uint16 windowResetBps; // min new-deposit-to-previous-balance ratio (in bps) to reset the window
-  }
-
-  struct Drip {
-    uint160 perBlockRate;
-    uint48 endReleaseBlock;
-    uint48 latestReleaseBlock;
-  }
 
   constructor(address tokenJar, address owner) Owned(owner) {
     require(owner != address(0), InvalidOwner());

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -39,8 +39,7 @@ contract FeeDripper is Owned, IFeeDripper {
   // mapping of currency to drip
   mapping(Currency => Drip) public drips;
 
-  constructor(address tokenJar, address owner) Owned(owner) {
-    require(owner != address(0), InvalidOwner());
+  constructor(address tokenJar) Owned(msg.sender) {
     require(tokenJar != address(0), InvalidTokenJar());
     TOKEN_JAR = tokenJar;
   }

--- a/src/feeAdapters/FeeDripper.sol
+++ b/src/feeAdapters/FeeDripper.sol
@@ -40,8 +40,8 @@ contract FeeDripper is Owned, IFeeDripper {
   }
 
   constructor(address tokenJar, address owner) Owned(owner) {
-    if (owner == address(0)) revert InvalidOwner();
-    if (tokenJar == address(0)) revert InvalidTokenJar();
+    require(owner != address(0), InvalidOwner());
+    require(tokenJar != address(0), InvalidTokenJar());
     TOKEN_JAR = tokenJar;
   }
 
@@ -103,8 +103,8 @@ contract FeeDripper is Owned, IFeeDripper {
 
   /// @inheritdoc IFeeDripper
   function setReleaseSettings(uint16 releaseWindow, uint16 windowResetBps) external onlyOwner {
-    if (releaseWindow == 0) revert InvalidReleaseWindow();
-    if (windowResetBps > BPS) revert InvalidWindowResetBps();
+    require(releaseWindow > 0, InvalidReleaseWindow());
+    require(windowResetBps <= BPS, InvalidWindowResetBps());
     releaseSettings =
       ReleaseSettings({releaseWindow: releaseWindow, windowResetBps: windowResetBps});
     emit ReleaseSettingsSet(releaseWindow, windowResetBps);

--- a/src/interfaces/IFeeDripper.sol
+++ b/src/interfaces/IFeeDripper.sol
@@ -43,14 +43,15 @@ interface IFeeDripper {
   function drip(Currency currency) external;
 
   /// @notice Releases accrued amount for `currency` to `TOKEN_JAR` without starting a new drip.
-  /// @dev Only accrual from the current stream is released.
+  /// @dev Releases accrual from the current stream. If the remaining balance (including idle
+  ///      deposits) is below the dust threshold, the entire balance is flushed.
   ///      Does not recompute rate or end block, and does not incorporate newly deposited idle
   ///      balance into the stream (that requires `drip()`).
   ///      Callable by anyone.
   /// @param currency The currency to release
   function release(Currency currency) external;
 
-  /// @notice Sets the release window.
+  /// @notice Sets the release window and window reset threshold.
   /// @dev Only callable by the owner.
   /// @param _releaseWindow The new release window
   /// @param _windowResetBps The new window reset basis points

--- a/src/interfaces/IFeeDripper.sol
+++ b/src/interfaces/IFeeDripper.sol
@@ -5,13 +5,20 @@ import {Currency} from "v4-core/types/Currency.sol";
 
 /// @title IFeeDripper
 interface IFeeDripper {
-  /// @notice Emitted when a drip is started for a given currency.
+  /// @notice Emitted when a drip schedule is updated for a given currency.
+  /// @param currency The currency address whose drip was updated
+  /// @param fullyReleasedBlock The block number at which the current drip will be fully released
+  /// @param perBlockRate The amount of tokens released per block
   event DripUpdated(
     address indexed currency, uint256 indexed fullyReleasedBlock, uint160 perBlockRate
   );
   /// @notice Emitted when a release to the token jar is completed.
+  /// @param currency The currency address that was released
+  /// @param amount The amount of tokens released
   event Released(address indexed currency, uint256 amount);
   /// @notice Emitted when the release settings are updated by the owner.
+  /// @param releaseWindow The new release window in blocks
+  /// @param windowResetBps The new window reset threshold in basis points
   event ReleaseSettingsSet(uint16 releaseWindow, uint16 windowResetBps);
 
   /// @notice Thrown when the owner address provided in the constructor is zero address.

--- a/src/interfaces/IFeeDripper.sol
+++ b/src/interfaces/IFeeDripper.sol
@@ -18,7 +18,9 @@ interface IFeeDripper {
   event Released(address indexed currency, uint256 amount);
   /// @notice Emitted when the release settings are updated by the owner.
   /// @param releaseWindow The new release window in blocks
-  /// @param windowResetBps The new window reset threshold in basis points
+  /// @param windowResetBps The new window reset threshold in basis points. If set too low, an
+  ///                        attacker can delay flow by adding enough balance to meet the reset
+  ///                        threshold and repeatedly calling `drip()`.
   event ReleaseSettingsSet(uint16 releaseWindow, uint16 windowResetBps);
 
   /// @notice Thrown when the token jar address provided in the constructor is zero address.

--- a/src/interfaces/IFeeDripper.sol
+++ b/src/interfaces/IFeeDripper.sol
@@ -21,8 +21,6 @@ interface IFeeDripper {
   /// @param windowResetBps The new window reset threshold in basis points
   event ReleaseSettingsSet(uint16 releaseWindow, uint16 windowResetBps);
 
-  /// @notice Thrown when the owner address provided in the constructor is zero address.
-  error InvalidOwner();
   /// @notice Thrown when the token jar address provided in the constructor is zero address.
   error InvalidTokenJar();
   /// @notice Thrown when the supplied release window is zero.

--- a/test/FeeDripper.t.sol
+++ b/test/FeeDripper.t.sol
@@ -17,7 +17,8 @@ contract FeeDripperTest is Test {
   ERC20Mock public erc20Currency;
 
   function setUp() public {
-    feeDripper = new FeeDripper(tokenJar, owner);
+    vm.prank(owner);
+    feeDripper = new FeeDripper(tokenJar);
     vm.deal(address(this), type(uint256).max);
     erc20Currency = new ERC20Mock();
   }
@@ -57,7 +58,7 @@ contract FeeDripperTest is Test {
 
   function test_constructor_revertsOnZeroTokenJar() public {
     vm.expectRevert(IFeeDripper.InvalidTokenJar.selector);
-    new FeeDripper(address(0), owner);
+    new FeeDripper(address(0));
   }
 
   function test_constructor_setsImmutables() public view {


### PR DESCRIPTION
Remediation for the OpenZeppelin FeeDripper audit ([final report](https://audits.openzeppelin.com/uniswap/uniswap-10-retainer-15-feedripper), delivered 2026-03-16).

Base is `496941fd` — the exact commit OZ reviewed — so this diff is the remediation delta against the audited artifact and nothing else. One commit per finding, reviewable against the report line by line.

## Findings addressed

| commit | finding |
|---|---|
| `ce1b207` | n-02 — fixed compiler version (`^0.8.29` → `0.8.29`) |
| `7e803df` | n-03 — `require` with custom errors |
| `0e19d0a` | n-04 — incomplete docstrings |
| `6f498e5` | n-05 — function visibility (`internal` → `private`) |
| `c2b4173` | n-06 — state variable visibility |
| `b60e612` | n-07 — redundant return statement |
| `10e0ed7` | n-08 — refactor opportunities |
| `795bf60` | n-09 — unit mismatch (documented) |
| `87486af` | n-10 — struct declarations moved above constants |
| `4660f40` | n-12 — misleading documentation |
| `665118d` | n-13 — constructor refactor |
| `9f1eff0` | l-01 — documented the risk of a low `windowResetBps` |

`src/feeAdapters/FeeDripper.sol`, `src/interfaces/IFeeDripper.sol`, and the test: +44 / −37.

## Behavioral change

`n-13` is the only commit that changes behavior rather than form:

```diff
-  constructor(address tokenJar, address owner) Owned(owner) {
-    if (owner == address(0)) revert InvalidOwner();
+  constructor(address tokenJar) Owned(msg.sender) {
```

Ownership is now the deployer rather than an explicit argument, and the `InvalidOwner()` zero-check is gone (unreachable once `msg.sender` is the owner).

This aligns FeeDripper with the rest of the repo — `TokenJar`, `V3FeeAdapter`, `V3OpenFeeAdapter`, `V4FeeAdapter` and `V4FeePolicy` all construct with `Owned(msg.sender)`. FeeDripper was the only contract taking an explicit owner argument. Deploy-then-transfer is the existing convention, documented on `TokenJar`'s constructor.

## Scope

`l-01` is resolved by documentation rather than a code change — the `windowResetBps` griefing path is described on `ReleaseSettingsSet` rather than prevented, consistent with the position that a governance-set parameter landing on a bad value is not an attack. Of the report's two Lows, `l-01` is the one represented here.

## Rebase

Both branches have been static since March. This branch is 31 commits ahead of `main` and 246 behind — the twelve fixes are small and replay onto two source files, but the surrounding repo (CI, snapshots, dependency versions) has moved considerably since.
