### PR TITLE
Proposal 8: Rotate Uniswap Earn vault sentinels

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -63,7 +63,8 @@ wrap_comments = true
 ignore = [
   "script/proposal-4/ProposalDescription.sol",
   "script/proposal-5/Description.sol",
-  "script/proposal-6/Description.sol"
+  "script/proposal-6/Description.sol",
+  "script/proposal-8/Description.sol"
   ]
 
 [lint]

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 solmate/=lib/solmate/
+briefcase/=lib/briefcase/src/
 solady/=lib/optimism/packages/contracts-bedrock/lib/solady/
 @eth-optimism-bedrock/=lib/optimism/packages/contracts-bedrock
 eas-contracts/=lib/dao-signer/lib/eas-contracts/contracts/

--- a/script/proposal-8/Constants.sol
+++ b/script/proposal-8/Constants.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+// -------------------------------------------------------------------------------------------------
+// Uniswap Earn
+//
+/// @dev Uniswap Earn vaults on Ethereum. Each is a Morpho `VaultV2` owned by the Timelock.
+/// @dev Structured to make it easy to add to govkit once this proposal is executed.
+struct Earn {
+  address uniUSDC;
+  address uniUSDT;
+  address uniETH;
+}
+
+library LibEarn {
+  function loadLatest() internal pure returns (Earn memory) {
+    return Earn({
+      uniUSDC: 0x5B453493D2328E7F747eb2e66446eFe707728be7,
+      uniUSDT: 0xb8274eFADB953FE9ae052D481a3FC5B6A3ceD703,
+      uniETH: 0x98D2b241DA14c5dd848812708Eb8A1F3c5512f9d
+    });
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Proposal parameters
+//
+/// @dev Sentinels this proposal adds and removes. Supplied by Gauntlet.
+library Sentinels {
+  address constant UNI_USDC_NEW = 0xF66b884D1906F37c1692CEa63564316FF975Cd75;
+  address constant UNI_USDC_LEGACY = 0xc3FE37DB03B5720D1684bE2e0200E0Af07853Ad9;
+
+  address constant UNI_USDT_NEW = 0xD9b023059dfD00C2DC68C4d8d0c70BCaA30577Db;
+  address constant UNI_USDT_LEGACY = 0x2745513325d4Ce5724e5B6Fb663356C427AfdeCc;
+
+  address constant UNI_ETH_NEW = 0x4Ff315B873d6e5Ad8ff7fF3e17D340862762cc2f;
+  address constant UNI_ETH_LEGACY = 0xc63A00De30AeB5666a8aC3478a4D119D38058c7E;
+}

--- a/script/proposal-8/Description.sol
+++ b/script/proposal-8/Description.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+string constant DESCRIPTION = "TODO";

--- a/script/proposal-8/Interfaces.sol
+++ b/script/proposal-8/Interfaces.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+/// @dev The subset of Morpho `VaultV2` this proposal touches. Source of the deployed vaults:
+///      https://etherscan.io/address/0x5B453493D2328E7F747eb2e66446eFe707728be7#code
+interface IVaultV2 {
+  function owner() external view returns (address);
+  function isSentinel(address account) external view returns (bool);
+  /// @dev Owner only. Not timelocked.
+  function setIsSentinel(address account, bool newIsSentinel) external;
+}

--- a/script/proposal-8/RotateEarnSentinels.s.sol
+++ b/script/proposal-8/RotateEarnSentinels.s.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {Uniswap} from "govkit/types/Uniswap.sol";
+import {ChainId} from "govkit/constants/ChainId.sol";
+import {Proposal} from "govkit/types/Proposal.sol";
+import {Call, LibCall} from "govkit/types/Call.sol";
+import {GovernanceSeatbelt} from "govkit/forge/GovernanceSeatbelt.sol";
+
+import {Earn, LibEarn, Sentinels} from "./Constants.sol";
+import {IVaultV2} from "./Interfaces.sol";
+import {DESCRIPTION} from "./Description.sol";
+
+contract RotateEarnSentinels is Script {
+  Uniswap internal uniswap;
+  Earn internal earn;
+
+  constructor() {
+    uniswap.loadLatest();
+    earn = LibEarn.loadLatest();
+  }
+
+  // Adding a sentinel is a `true` flag, removing a sentinel is a `false` flag.
+  bool internal constant REMOVE = false;
+  bool internal constant ADD = true;
+
+  /// @dev Asserts the state the proposal depends on, then writes it for Governance Seatbelt.
+  ///      Run against Ethereum: `forge script ... --rpc-url mainnet`.
+  function run() external {
+    require(keccak256(bytes(DESCRIPTION)) != keccak256(bytes("TODO")), "DESCRIPTION not set");
+
+    preflight();
+
+    string memory path = "./out/.seatbelt/RotateEarnSentinelsProposal.json";
+    vm.createDir("./out/.seatbelt/", true);
+    vm.writeFile({
+      path: path,
+      data: GovernanceSeatbelt.toJson({
+        proposal: proposal(), governorBravo: uniswap.ethereum.governorBravo
+      })
+    });
+    console.log("wrote", path);
+  }
+
+  /// @dev Every vault is owned by the Timelock, has its legacy sentinel set, and does not have its
+  ///      new sentinel set. Also a standalone entrypoint: `--sig "preflight()"`.
+  function preflight() public view {
+    require(block.chainid == ChainId.Ethereum, "not Ethereum");
+    console.log("preflight at block", block.number);
+
+    address timelock = uniswap.ethereum.timelock;
+
+    // UNI-USDC
+    require(IVaultV2(earn.uniUSDC).owner() == timelock, "uniUSDC.owner");
+    require(IVaultV2(earn.uniUSDC).isSentinel(Sentinels.UNI_USDC_LEGACY), "uniUSDC.legacySentinel");
+    require(!IVaultV2(earn.uniUSDC).isSentinel(Sentinels.UNI_USDC_NEW), "uniUSDC.newSentinel");
+    console.log("uniUSDC ready", earn.uniUSDC);
+
+    // UNI-USDT
+    require(IVaultV2(earn.uniUSDT).owner() == timelock, "uniUSDT.owner");
+    require(IVaultV2(earn.uniUSDT).isSentinel(Sentinels.UNI_USDT_LEGACY), "uniUSDT.legacySentinel");
+    require(!IVaultV2(earn.uniUSDT).isSentinel(Sentinels.UNI_USDT_NEW), "uniUSDT.newSentinel");
+    console.log("uniUSDT ready", earn.uniUSDT);
+
+    // UNI-ETH
+    require(IVaultV2(earn.uniETH).owner() == timelock, "uniETH.owner");
+    require(IVaultV2(earn.uniETH).isSentinel(Sentinels.UNI_ETH_LEGACY), "uniETH.legacySentinel");
+    require(!IVaultV2(earn.uniETH).isSentinel(Sentinels.UNI_ETH_NEW), "uniETH.newSentinel");
+    console.log("uniETH ready", earn.uniETH);
+  }
+
+  /// @dev Every vault has its new sentinel set and its legacy sentinel unset. The fork test calls
+  ///      this after executing the proposal; after the proposal executes onchain, run it against
+  ///      Ethereum to verify the outcome: `--sig "postflight()"`.
+  function postflight() public view {
+    require(block.chainid == ChainId.Ethereum, "not Ethereum");
+    console.log("postflight at block", block.number);
+
+    // UNI-USDC
+    require(IVaultV2(earn.uniUSDC).isSentinel(Sentinels.UNI_USDC_NEW), "uniUSDC.newSentinel");
+    require(!IVaultV2(earn.uniUSDC).isSentinel(Sentinels.UNI_USDC_LEGACY), "uniUSDC.legacySentinel");
+    console.log("uniUSDC sentinel rotated", earn.uniUSDC);
+
+    // UNI-USDT
+    require(IVaultV2(earn.uniUSDT).isSentinel(Sentinels.UNI_USDT_NEW), "uniUSDT.newSentinel");
+    require(!IVaultV2(earn.uniUSDT).isSentinel(Sentinels.UNI_USDT_LEGACY), "uniUSDT.legacySentinel");
+    console.log("uniUSDT sentinel rotated", earn.uniUSDT);
+
+    // UNI-ETH
+    require(IVaultV2(earn.uniETH).isSentinel(Sentinels.UNI_ETH_NEW), "uniETH.newSentinel");
+    require(!IVaultV2(earn.uniETH).isSentinel(Sentinels.UNI_ETH_LEGACY), "uniETH.legacySentinel");
+    console.log("uniETH sentinel rotated", earn.uniETH);
+  }
+
+  /// @dev The proposal, built here so the fork test executes the same calls the script writes.
+  function proposal() public view returns (Proposal memory) {
+    // ---------------------------------------------------------------------------------------------
+    // 00: Add new sentinel to uniUSDC
+    //
+    Call memory addUniUSDCSentinel = Call({
+      target: earn.uniUSDC,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_USDC_NEW, ADD))
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // 01: Remove legacy sentinel from uniUSDC
+    //
+    Call memory removeUniUSDCSentinel = Call({
+      target: earn.uniUSDC,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_USDC_LEGACY, REMOVE))
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // 02: Add new sentinel to uniUSDT
+    //
+    Call memory addUniUSDTSentinel = Call({
+      target: earn.uniUSDT,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_USDT_NEW, ADD))
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // 03: Remove legacy sentinel from uniUSDT
+    //
+    Call memory removeUniUSDTSentinel = Call({
+      target: earn.uniUSDT,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_USDT_LEGACY, REMOVE))
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // 04: Add new sentinel to uniETH
+    //
+    Call memory addUniETHSentinel = Call({
+      target: earn.uniETH,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_ETH_NEW, ADD))
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // 05: Remove legacy sentinel from uniETH
+    //
+    Call memory removeUniETHSentinel = Call({
+      target: earn.uniETH,
+      value: 0,
+      data: abi.encodeCall(IVaultV2.setIsSentinel, (Sentinels.UNI_ETH_LEGACY, REMOVE))
+    });
+
+    return Proposal({
+      description: DESCRIPTION,
+      calls: LibCall.newCalls(
+        [
+          addUniUSDCSentinel,
+          removeUniUSDCSentinel,
+          addUniUSDTSentinel,
+          removeUniUSDTSentinel,
+          addUniETHSentinel,
+          removeUniETHSentinel
+        ]
+      )
+    });
+  }
+}

--- a/test/end-to-end/proposal-8/RotateEarnSentinels.fork.t.sol
+++ b/test/end-to-end/proposal-8/RotateEarnSentinels.fork.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Uniswap} from "govkit/types/Uniswap.sol";
+import {Call} from "govkit/types/Call.sol";
+
+import {RotateEarnSentinels} from "../../../script/proposal-8/RotateEarnSentinels.s.sol";
+
+contract RotateEarnSentinelsForkTest is Test {
+  Uniswap internal uniswap;
+  RotateEarnSentinels internal script;
+
+  function setUp() public {
+    vm.createSelectFork("mainnet", 25_904_682);
+    uniswap.loadLatest();
+    script = new RotateEarnSentinels();
+  }
+
+  /// @dev Preflight: the script's own precondition check holds at the pinned block.
+  function test_preflight_state() public {
+    script.preflight();
+  }
+
+  /// @dev Postflight: the proposal's calls, sent by the Timelock, flip exactly the intended flags.
+  function test_execute_as_timelock() public {
+    // Get the proposal's calls
+    Call[] memory calls = script.proposal().calls;
+    assertEq(calls.length, 6);
+
+    vm.startPrank(uniswap.ethereum.timelock);
+    // Execute the proposal's calls
+    for (uint256 i; i < calls.length; i++) {
+      (bool ok,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+      assertTrue(ok);
+    }
+    vm.stopPrank();
+
+    // Check that the sentinels are set as intended
+    script.postflight();
+  }
+}


### PR DESCRIPTION
Rotates the sentinel on each of the three Uniswap Earn vaults on Ethereum: uniUSDC, uniUSDT, and uniETH. For each vault the proposal adds one new sentinel and removes one legacy sentinel, six direct calls from the Timelock to `setIsSentinel`. No prerequisite deployments.

`script/proposal-8/RotateEarnSentinels.s.sol` asserts each vault's preflight state before writing the Seatbelt JSON, and exposes `preflight()` and `postflight()` for checking mainnet before and after execution. The fork test runs preflight, sends the proposal's calls as the Timelock, and runs postflight.

The proposal description is a placeholder and will be filled in before this leaves draft.